### PR TITLE
add option to submit logs when download fails

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -471,6 +471,8 @@ class MerginProjectsManager(object):
                     dlg.exception_details(),
                     "Project download",
                     f"Failed to download project {project_name} due to an unhandled exception.",
+                    dlg.log_file,
+                    self.mc.username(),
                 )
             return
         if not dlg.is_complete:

--- a/Mergin/sync_dialog.py
+++ b/Mergin/sync_dialog.py
@@ -48,6 +48,7 @@ class SyncDialog(QDialog):
         self.exception_tb = None
         self.is_complete = False
         self.job = None
+        self.log_file = None
 
         self.timer = QTimer(self)
         self.timer.setInterval(100)
@@ -72,6 +73,8 @@ class SyncDialog(QDialog):
             self.pull_cancel()
 
     def reset_operation(self, success, close, exception=None):
+        if self.job.failure_log_file is not None:
+            self.log_file = self.job.failure_log_file
         self.operation = None
         self.mergin_client = None
         self.target_dir = None

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -900,7 +900,7 @@ def login_error_message(e):
     QMessageBox.critical(None, "Login failed", msg, QMessageBox.Close)
 
 
-def unhandled_exception_message(error_details, dialog_title, error_text):
+def unhandled_exception_message(error_details, dialog_title, error_text, log_file=None, username=None):
     msg = (
         error_text + "<p>This should not happen, "
         '<a href="https://github.com/MerginMaps/qgis-mergin-plugin/issues">'
@@ -910,7 +910,20 @@ def unhandled_exception_message(error_details, dialog_title, error_text):
     box.setIcon(QMessageBox.Critical)
     box.setWindowTitle(dialog_title)
     box.setText(msg)
-    box.setDetailedText(error_details)
+    if log_file is None:
+        box.setDetailedText(error_details)
+    else:
+        error_details = (
+            "An error occured during project synchronisation. The log was saved to "
+            f"{log_file}. Click 'Send logs' to send a diagnostic log to the developers "
+            "to help them determine the exact cause of the problem.\n\n"
+            "The log does not contain any of your data, only file names. "
+            "It would be useful if you also send a mail to support@merginmaps.com "
+            "and briefly describe the problem to add more context to the diagnostic log."
+        )
+        box.setDetailedText(error_details)
+        btn = box.addButton("Send logs", QMessageBox.ActionRole)
+        btn.clicked.connect(lambda: send_logs(username, log_file))
     box.exec_()
 
 


### PR DESCRIPTION
When the project is downloaded for the first time and the download crashes during this process mergin log is removed, making it much harder to debug and fix possible issues. This PR adds an option to the error dialog to send log to the developers. Requires Python client with https://github.com/MerginMaps/mergin-py-client/pull/182.

Refs https://app.clickup.com/t/862k79n4m