### PR TITLE
Add dock with project history

### DIFF
--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -329,6 +329,8 @@ def make_version_changes_layers(project_path, version):
             geodiff.schema("sqlite", "", gpkg_file, schema_file)
 
         changeset_file = find_changeset_file(f, version_dir)
+        if changeset_file is None:
+            continue
 
         with open(schema_file, encoding="utf-8") as fl:
             data = fl.read()

--- a/Mergin/images/default/tabler_icons/arrow-back-up.svg
+++ b/Mergin/images/default/tabler_icons/arrow-back-up.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-back-up" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M9 14l-4 -4l4 -4" />
+  <path d="M5 10h11a4 4 0 1 1 0 8h-1" />
+</svg>
+
+

--- a/Mergin/images/default/tabler_icons/file-description.svg
+++ b/Mergin/images/default/tabler_icons/file-description.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-file-description" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  <path d="M9 17h6" />
+  <path d="M9 13h6" />
+</svg>
+
+

--- a/Mergin/images/default/tabler_icons/filter.svg
+++ b/Mergin/images/default/tabler_icons/filter.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-filter" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227z" />
+</svg>
+
+

--- a/Mergin/images/default/tabler_icons/history.svg
+++ b/Mergin/images/default/tabler_icons/history.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-history" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 8l0 4l2 2" />
+  <path d="M3.05 11a9 9 0 1 1 .5 4m-.5 5v-5h5" />
+</svg>
+
+

--- a/Mergin/images/white/tabler_icons/arrow-back-up.svg
+++ b/Mergin/images/white/tabler_icons/arrow-back-up.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-back-up" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="#fff" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M9 14l-4 -4l4 -4" />
+  <path d="M5 10h11a4 4 0 1 1 0 8h-1" />
+</svg>
+
+

--- a/Mergin/images/white/tabler_icons/file-description.svg
+++ b/Mergin/images/white/tabler_icons/file-description.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-file-description" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="#fff" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  <path d="M9 17h6" />
+  <path d="M9 13h6" />
+</svg>
+
+

--- a/Mergin/images/white/tabler_icons/filter.svg
+++ b/Mergin/images/white/tabler_icons/filter.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-filter" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="#fff" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227z" />
+</svg>
+
+

--- a/Mergin/images/white/tabler_icons/history.svg
+++ b/Mergin/images/white/tabler_icons/history.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-history" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="#fff" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 8l0 4l2 2" />
+  <path d="M3.05 11a9 9 0 1 1 .5 4m-.5 5v-5h5" />
+</svg>
+
+

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -317,6 +317,7 @@ class MerginPlugin:
             self.mc = dlg.writeSettings()
             self.on_config_changed()
             self.show_browser_panel()
+            self.history_dock_widget.set_mergin_client(self.mc)
 
     def configure_db_sync(self):
         """Open db-sync setup wizard."""

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -350,6 +350,8 @@ class MerginPlugin:
 
     def toggle_project_history_action(self, visible):
         self.history_dock_action.setChecked(visible)
+        # load project history when dock becomes visible
+        self.history_dock_widget.update_ui()
 
     def show_no_workspaces_dialog(self):
         msg = (
@@ -486,6 +488,7 @@ class MerginPlugin:
     def current_project_sync(self):
         """Synchronise current Mergin Maps project."""
         self.manager.project_status(self.mergin_proj_dir)
+        self.history_dock_widget.get_project_history()
 
     def find_project(self):
         """Open new Find Mergin Maps project dialog"""

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -244,6 +244,7 @@ class ChangesetsDownloader(QThread):
             self.finished.emit("This version does not contain changes in the project layers.")
             return
 
+        change = False
         for f in files:
             if self.isInterruptionRequested():
                 return
@@ -251,9 +252,17 @@ class ChangesetsDownloader(QThread):
             if "diff" not in f:
                 continue
             file_diffs = self.mc.download_file_diffs(self.mp.dir, f["path"], [f"v{self.version}"])
+
+            if len(file_diffs) > 0:
+                change = True
+
             full_gpkg = self.mp.fpath_cache(f["path"], version=f"v{self.version}")
             if not os.path.exists(full_gpkg):
                 self.mc.download_file(self.mp.dir, f["path"], full_gpkg, f"v{self.version}")
+
+        if not change:
+            self.finished.emit("No changes to the current project layers for this version.")
+            return
 
         self.finished.emit("")
 

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -6,7 +6,7 @@ from urllib.error import URLError
 from qgis.PyQt import uic
 from qgis.PyQt.QtGui import QIcon, QStandardItemModel, QStandardItem, QFont, QFontMetrics
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal, QSortFilterProxyModel, QRect, QMargins, QSize
-from qgis.PyQt.QtWidgets import QMenu, QAbstractItemDelegate, QStyle
+from qgis.PyQt.QtWidgets import QMenu, QAbstractItemDelegate, QMessageBox
 
 from qgis.gui import QgsDockWidget
 from qgis.core import Qgis
@@ -304,15 +304,15 @@ class ProjectHistoryDockWidget(QgsDockWidget):
                 info = self.mc.project_info(self.project_full_name, version=f"v{version}")
                 files = [f for f in info["files"] if is_versioned_file(f["path"])]
                 if not files:
-                    iface.messageBar().pushMessage(
-                        "Mergin", "This version does not contain changes in the project layers.", Qgis.Info
+                    QMessageBox.information(
+                        None, "Mergin", "This version does not contain changes in the project layers."
                     )
                     return
 
                 has_history = any("diff" in f for f in files)
                 if not has_history:
-                    iface.messageBar().pushMessage(
-                        "Mergin", "This version does not contain changes in the project layers.", Qgis.Info
+                    QMessageBox.information(
+                        None, "Mergin", "This version does not contain changes in the project layers."
                     )
                     return
 

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -201,7 +201,7 @@ class ProjectHistoryDockWidget(QgsDockWidget):
         self.update_ui()
 
     def get_project_history(self):
-        self.project_full_name = self.mp.metadata["name"]
+        self.project_full_name = self.mp.project_full_name()
         info = self.mc.project_info(self.project_full_name)
         self.last_project_version = info["version"]
 

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -4,17 +4,17 @@ import json
 from urllib.error import URLError
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtGui import QIcon, QStandardItemModel, QStandardItem, QFont, QFontMetrics
-from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal, QSortFilterProxyModel, QRect, QMargins, QSize
-from qgis.PyQt.QtWidgets import QMenu, QAbstractItemDelegate, QMessageBox
+from qgis.PyQt.QtGui import QIcon, QFont
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal, QSortFilterProxyModel, QAbstractItemModel, QModelIndex
+from qgis.PyQt.QtWidgets import QMenu, QMessageBox
 
 from qgis.gui import QgsDockWidget
 from qgis.core import Qgis
-from qgis.utils import OverrideCursor, iface
+from qgis.utils import iface
 
 from .diff_dialog import DiffViewerDialog
 from .version_details_dialog import VersionDetailsDialog
-from .utils import check_mergin_subdirs, icon_path, ClientError, is_versioned_file
+from .utils import check_mergin_subdirs, icon_path, ClientError, is_versioned_file, contextual_date, format_datetime
 
 from .mergin.merginproject import MerginProject
 from .mergin.utils import int_version
@@ -23,81 +23,139 @@ from .mergin.utils import int_version
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_project_history_dock.ui")
 
 
-class VersionsModel(QStandardItemModel):
-    VERSION = Qt.UserRole + 1
-    AUTHOR = Qt.UserRole + 2
-    CREATED = Qt.UserRole + 3
-
-    def __init__(self, versions=None):
-        super(VersionsModel, self).__init__()
-        if versions:
-            self.appendVersions(versions)
-
-    def appendVersions(self, versions):
-        for item in self.createItems(versions):
-            self.appendRow(item)
-
-    @staticmethod
-    def createItems(versions):
-        items = []
-        for version in versions:
-            item = QStandardItem(version["name"])
-            item.setData(int_version(version["name"]), VersionsModel.VERSION)
-            item.setData(version["author"], VersionsModel.AUTHOR)
-            item.setData(version["created"], VersionsModel.CREATED)
-            items.append(item)
-        return items
-
-
-class VersionItemDelegate(QAbstractItemDelegate):
+class Node:
     def __init__(self):
-        super(VersionItemDelegate, self).__init__()
+        self.parent = None
+        self.children = list()
 
-    def sizeHint(self, option, index):
-        fm = QFontMetrics(option.font)
-        return QSize(150, fm.height() * 2 + fm.leading())
+    def add_child_node(self, node):
+        if node is None:
+            return
 
-    def paint(self, painter, option, index):
-        font = QFont(option.font)
-        fm = QFontMetrics(font)
-        padding = fm.lineSpacing() // 2
+        node.parent = self
+        self.children.append(node)
 
-        w = QRect(option.rect).width()
-        dw = w // 5
+    def delete_children(self):
+        self.children.clear()
 
-        versionRect = QRect(option.rect)
-        versionRect.setLeft(versionRect.left() + padding)
-        versionRect.setTop(versionRect.top() + padding)
-        versionRect.setRight(versionRect.left() + dw)
-        versionRect.setHeight(fm.lineSpacing())
 
-        authorRect = QRect(option.rect)
-        authorRect.setLeft(versionRect.right() + padding)
-        authorRect.setTop(authorRect.top() + padding)
-        authorRect.setRight(authorRect.left() + dw * 2)
-        authorRect.setHeight(fm.lineSpacing())
+class VersionsModel(QAbstractItemModel):
+    VERSION = Qt.UserRole + 1
 
-        dateRect = QRect(option.rect)
-        dateRect.setLeft(authorRect.right() + padding)
-        dateRect.setTop(dateRect.top() + padding)
-        dateRect.setRight(dateRect.right() - padding)
-        dateRect.setHeight(fm.lineSpacing())
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.root_node = Node()
 
-        borderRect = QRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)))
+        self.current_version = None
+        self.versions = []
 
-        painter.save()
-        if option.state & QStyle.State_Selected:
-            painter.fillRect(borderRect, option.palette.highlight())
-        painter.drawRect(borderRect)
+    def clear(self):
+        self.beginResetModel()
+        self.root_node.delete_children()
+        self.versions.clear()
+        self.rebuild()
+        self.endResetModel()
 
-        elided_text = fm.elidedText(index.data(), Qt.ElideRight, versionRect.width())
-        painter.drawText(versionRect, Qt.AlignLeading, elided_text)
-        elided_text = fm.elidedText(index.data(VersionsModel.AUTHOR), Qt.ElideRight, authorRect.width())
-        painter.drawText(authorRect, Qt.AlignLeading, elided_text)
-        elided_text = fm.elidedText(index.data(VersionsModel.CREATED), Qt.ElideRight, dateRect.width())
-        painter.drawText(dateRect, Qt.AlignLeading, elided_text)
+    def add_versions(self, versions):
+        self.versions.extend(versions)
+        self.rebuild()
 
-        painter.restore()
+    def rebuild(self):
+        self.beginResetModel()
+        self.root_node.delete_children()
+        for v in self.versions:
+            version_node = Node()
+            self.root_node.add_child_node(version_node)
+        self.endResetModel()
+
+    def set_current_version(self, version):
+        self.current_version = version
+
+    def index2node(self, index):
+        if not index.isValid():
+            return self.root_node
+
+        return index.internalPointer()
+
+    def data(self, index, role=Qt.DisplayRole):
+        if not index.isValid():
+            return None
+
+        idx = index.row()
+        if role == Qt.DisplayRole:
+            if index.column() == 0:
+                return self.versions[idx]["name"]
+            elif index.column() == 1:
+                return self.versions[idx]["author"]
+            elif index.column() == 2:
+                return contextual_date(self.versions[idx]["created"])
+            else:
+                return None
+        elif role == Qt.ToolTipRole:
+            if index.column() == 2:
+                return format_datetime(self.versions[idx]["created"])
+        elif role == Qt.FontRole:
+            if self.versions[idx]["name"] == self.current_version:
+                font = QFont()
+                font.setBold(True)
+                return font
+        elif role == VersionsModel.VERSION:
+            return int_version(self.versions[idx]["name"])
+        else:
+            return None
+
+    def headerData(self, section, orientation, role):
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            if section == 0:
+                return "Version"
+            elif section == 1:
+                return "Author"
+            elif section == 2:
+                return "Created"
+            else:
+                return None
+        return None
+
+    def rowCount(self, parent=QModelIndex()):
+        node = self.index2node(parent)
+        if node is None:
+            return 0
+
+        return len(node.children)
+
+    def columnCount(self, parent=QModelIndex()):
+        return 3
+
+    def index(self, row, column, parent=QModelIndex()):
+        if not self.hasIndex(row, column, parent):
+            return QModelIndex()
+
+        node = self.index2node(parent)
+        if node is None:
+            return QModelIndex()
+
+        return self.createIndex(row, column, node.children[row])
+
+    def parent(self, index):
+        if not index.isValid():
+            return QModelIndex()
+
+        node = self.index2node(index)
+        if node is not None:
+            return self.index_of_parent_tree_node(node.parent)
+        else:
+            return QModelIndex()
+
+    def index_of_parent_tree_node(self, parent_node):
+        grand_parent_node = parent_node.parent
+        if grand_parent_node is None:
+            return QModelIndex()
+
+        row = grand_parent_node.children.index(parent_node)
+        return self.createIndex(row, 0, parent_node)
+
+    def item_from_index(self, index):
+        return self.versions[index.row()]
 
 
 class VersionsFetcher(QThread):
@@ -107,7 +165,7 @@ class VersionsFetcher(QThread):
 
     finished = pyqtSignal(list)
 
-    def __init__(self, mc, project_name, page):
+    def __init__(self, mc, project_name, page, since=None, to=None):
         """
         VersionsFetcher constructor
 
@@ -119,11 +177,19 @@ class VersionsFetcher(QThread):
         self.mc = mc
         self.project_name = project_name
         self.page = page
+        self.since = since
+        self.to = to
 
     def isFetchingNextPage(self):
         return self.page > 1
 
     def run(self):
+        if self.since and self.to:
+            self.fetch_missed_versions()
+        else:
+            self.fetch_page()
+
+    def fetch_page(self):
         try:
             params = {"page": self.page, "per_page": 100, "descending": True}
             resp = self.mc.get("/v1/project/versions/paginated/{}".format(self.project_name), params)
@@ -135,14 +201,68 @@ class VersionsFetcher(QThread):
         except (URLError, ClientError) as e:
             return
 
+    def fetch_missed_versions(self):
+        try:
+            versions = self.mc.project_versions(self.project_name, self.since, self.to)
+            if self.isInterruptionRequested():
+                return
+            # first item corresponds to the local project version and is not needed
+            self.finished.emit(versions[1:])
+        except (URLError, ClientError) as e:
+            return
+
+
+class ChangesetsDownloader(QThread):
+    """
+    Class to download version changesets in background worker thread
+    """
+
+    finished = pyqtSignal(str)
+
+    def __init__(self, mc, mp, version):
+        """
+        ChangesetsDownloader constructor
+
+        :param mc: MerginClient instance
+        :param mp: MerginProject instance
+        :param version: project version to download
+        """
+        super(ChangesetsDownloader, self).__init__()
+        self.mc = mc
+        self.mp = mp
+        self.version = version
+
+    def run(self):
+        info = self.mc.project_info(self.mp.project_full_name(), version=f"v{self.version}")
+        files = [f for f in info["files"] if is_versioned_file(f["path"])]
+        if not files:
+            self.finished.emit("This version does not contain changes in the project layers.")
+            return
+
+        has_history = any("diff" in f for f in files)
+        if not has_history:
+            self.finished.emit("This version does not contain changes in the project layers.")
+            return
+
+        for f in files:
+            if self.isInterruptionRequested():
+                return
+
+            if "diff" not in f:
+                continue
+            file_diffs = self.mc.download_file_diffs(self.mp.dir, f["path"], [f"v{self.version}"])
+            full_gpkg = self.mp.fpath_cache(f["path"], version=f"v{self.version}")
+            if not os.path.exists(full_gpkg):
+                self.mc.download_file(self.mp.dir, f["path"], full_gpkg, f"v{self.version}")
+
+        self.finished.emit("")
+
 
 class ProjectHistoryDockWidget(QgsDockWidget):
     def __init__(self, mc):
         QgsDockWidget.__init__(self)
         self.ui = uic.loadUi(ui_file, self)
 
-        self.filter_btn.setIcon(QIcon(icon_path("filter.svg")))
-        self.filter_btn.setEnabled(False)
         self.view_changes_btn.setIcon(QIcon(icon_path("file-diff.svg")))
         self.view_changes_btn.setEnabled(False)
         self.view_changes_btn.clicked.connect(self.show_changes)
@@ -150,24 +270,25 @@ class ProjectHistoryDockWidget(QgsDockWidget):
         self.mc = mc
         self.mp = None
         self.project_path = None
-        self.project_full_name = None
-        self.last_project_version = None
+        self.server_project_version = None
+        self.local_project_version = None
+        self.last_seen_version = None
 
         self.need_to_fetch_next_page = False
         self.request_page = None
-        self.fetcher = None
+        self.versions_fetcher = None
+        self.diff_downloader = None
 
         self.model = VersionsModel()
         self.proxy = QSortFilterProxyModel()
         self.proxy.setSourceModel(self.model)
         self.proxy.setSortRole(VersionsModel.VERSION)
+        self.proxy.sort(0, Qt.DescendingOrder)
+        self.versions_tree.setModel(self.proxy)
+        self.versions_tree.verticalScrollBar().valueChanged.connect(self.on_scrollbar_changed)
+        self.versions_tree.customContextMenuRequested.connect(self.show_context_menu)
 
-        self.versions_list.setItemDelegate(VersionItemDelegate())
-        self.versions_list.setModel(self.proxy)
-        self.versions_list.verticalScrollBar().valueChanged.connect(self.on_scrollbar_changed)
-        self.versions_list.customContextMenuRequested.connect(self.show_context_menu)
-
-        selectionModel = self.versions_list.selectionModel()
+        selectionModel = self.versions_tree.selectionModel()
         selectionModel.selectionChanged.connect(self.on_selection_changed)
 
         self.update_ui()
@@ -193,56 +314,103 @@ class ProjectHistoryDockWidget(QgsDockWidget):
             return
 
         self.mp = MerginProject(self.project_path)
+        self.local_project_version = self.mp.version()
+        try:
+            ws_id = self.mp.workspace_id()
+        except ClientError as e:
+            self.info_label.setText(str(e))
+            self.stackedWidget.setCurrentIndex(0)
+            return
+
+        # check if user has permissions
+        resp = self.mc.get(f"/v1/workspace/{ws_id}/usage")
+        usage = json.load(resp)
+        if not usage["view_history"]["allowed"]:
+            self.info_label.setText("The workspace does not allow to view project history.")
+            self.stackedWidget.setCurrentIndex(0)
+            return
+
         self.stackedWidget.setCurrentIndex(1)
         self.get_project_history()
 
     def set_project(self, project_path):
-        self.project_path = project_path
-        self.update_ui()
+        if self.project_path is None or self.project_path != project_path:
+            self.project_path = project_path
+            self.model.clear()
+            self.update_ui()
 
     def get_project_history(self):
-        self.project_full_name = self.mp.project_full_name()
-        info = self.mc.project_info(self.project_full_name)
-        self.last_project_version = info["version"]
+        """Fetch project history from the server starting from the latest server
+        version of the project.
+        """
+        if not self.isVisible():
+            return
 
-        self.fetch_from_server()
+        info = self.mc.project_info(self.mp.project_full_name())
+        self.server_project_version = info["version"]
+
+        if self.model.rowCount() == 0:
+            self.load_history()
+
+        if self.last_seen_version and self.server_project_version > self.last_seen_version:
+            self.update_history()
 
     def on_scrollbar_changed(self, value):
         if not self.need_to_fetch_next_page:
             return
 
-        if self.versions_list.verticalScrollBar().maximum() <= value:
-            self.fetch_from_server(fetch_next_page=True)
+        if self.versions_tree.verticalScrollBar().maximum() <= value:
+            self.load_history(fetch_next_page=True)
 
-    def fetch_from_server(self, fetch_next_page=False):
+    def load_history(self, fetch_next_page=False):
+        """Loads project history via paginated requests"""
         if not fetch_next_page:
-            self.request_page = math.ceil(int_version(self.last_project_version) / 100)
-            self.versions_list.clearSelection()
-            self.versions_list.scrollToTop()
+            self.request_page = math.ceil(int_version(self.server_project_version) / 100)
+            self.versions_tree.clearSelection()
+            self.versions_tree.scrollToTop()
             self.model.clear()
 
-        if self.fetcher and self.fetcher.isRunning():
-            if fetch_next_page and self.fetcher.isFetchingNextPage():
+        if self.versions_fetcher and self.versions_fetcher.isRunning():
+            if fetch_next_page and self.versions_fetcher.isFetchingNextPage():
                 # We only want one fetch_next_page request at a time
                 return
             else:
                 # Let's replace the existing request with the new one
-                self.fetcher.requestInterruption()
+                self.versions_fetcher.requestInterruption()
 
-        self.fetcher = VersionsFetcher(self.mc, self.project_full_name, self.request_page)
-        self.fetcher.finished.connect(self.handle_server_response)
-        self.fetcher.start()
+        self.versions_fetcher = VersionsFetcher(self.mc, self.mp.project_full_name(), self.request_page)
+        self.versions_fetcher.finished.connect(self.handle_server_response)
+        self.versions_fetcher.start()
 
-    def handle_server_response(self, versions):
+    def update_history(self):
+        """Fetches information about project versions after sync"""
+        if self.versions_fetcher and self.versions_fetcher.isRunning():
+            self.versions_fetcher.requestInterruption()
+
+        self.versions_fetcher = VersionsFetcher(
+            self.mc, self.mp.project_full_name(), 1, self.last_seen_version, self.server_project_version
+        )
+        self.versions_fetcher.finished.connect(lambda versions: self.handle_server_response(versions, False))
+        self.versions_fetcher.start()
+
+    def handle_server_response(self, versions, check_next_page=True):
         try:
-            last_fetched_version = versions[-1]["name"]
-            if last_fetched_version != "v1":
-                self.request_page = self.request_page - 1
-                self.need_to_fetch_next_page = True
+            if self.last_seen_version is None:
+                self.last_seen_version = versions[0]["name"]
             else:
-                self.need_to_fetch_next_page = False
+                if self.last_seen_version < versions[0]["name"]:
+                    self.last_seen_version = versions[0]["name"]
 
-            self.model.appendVersions(versions)
+            if check_next_page:
+                last_fetched_version = versions[-1]["name"]
+                if last_fetched_version != "v1":
+                    self.request_page = self.request_page - 1
+                    self.need_to_fetch_next_page = True
+                else:
+                    self.need_to_fetch_next_page = False
+
+            self.model.set_current_version(self.mp.version())
+            self.model.add_versions(versions)
         except KeyError:
             pass
 
@@ -254,84 +422,80 @@ class ProjectHistoryDockWidget(QgsDockWidget):
             self.view_changes_btn.setEnabled(False)
 
     def show_changes(self):
-        if self.versions_list.selectedIndexes():
-            index = self.versions_list.selectedIndexes()[0]
+        """Shows a Diff Viewer dialog with changes made in the currently selected version"""
+        if self.versions_tree.selectedIndexes():
+            index = self.versions_tree.selectedIndexes()[0]
             source_index = self.proxy.mapToSource(index)
-            item = self.model.itemFromIndex(source_index)
-            version = item.data(VersionsModel.VERSION)
-            self.view_changes(version)
+            item = self.model.item_from_index(source_index)
+            self.view_changes(int_version(item["name"]))
 
     def show_context_menu(self, pos):
-        index = self.versions_list.indexAt(pos)
+        """Shows context menu in the project history dock"""
+        index = self.versions_tree.indexAt(pos)
         if not index.isValid():
             return
 
         source_index = self.proxy.mapToSource(index)
-        item = self.model.itemFromIndex(source_index)
-        version = item.data(VersionsModel.VERSION)
+        item = self.model.item_from_index(source_index)
+        version = int_version(item["name"])
 
         menu = QMenu()
         view_details_action = menu.addAction("Version details")
         view_details_action.setIcon(QIcon(icon_path("file-description.svg")))
-        view_details_action.triggered.connect(lambda: self.version_details(version))
+        view_details_action.triggered.connect(lambda: self.version_details(item))
         view_changes_action = menu.addAction("View changes")
         view_changes_action.setIcon(QIcon(icon_path("file-diff.svg")))
         view_changes_action.triggered.connect(lambda: self.view_changes(version))
-        download_action = menu.addAction("Download this version")
-        download_action.setIcon(QIcon(icon_path("cloud-download.svg")))
-        download_action.triggered.connect(self.download_version)
-        revert_action = menu.addAction("Revert to this version")
-        revert_action.setIcon(QIcon(icon_path("arrow-back-up.svg")))
-        revert_action.triggered.connect(self.revert_to_version)
-        undo_action = menu.addAction("Undo changes in this version")
-        undo_action.setIcon(QIcon(icon_path("arrow-back-up.svg")))
-        undo_action.triggered.connect(self.undo_changes)
+        # download_action = menu.addAction("Download this version")
+        # download_action.setIcon(QIcon(icon_path("cloud-download.svg")))
+        # download_action.triggered.connect(self.download_version)
+        # revert_action = menu.addAction("Revert to this version")
+        # revert_action.setIcon(QIcon(icon_path("arrow-back-up.svg")))
+        # revert_action.triggered.connect(self.revert_to_version)
+        # undo_action = menu.addAction("Undo changes in this version")
+        # undo_action.setIcon(QIcon(icon_path("arrow-back-up.svg")))
+        # undo_action.triggered.connect(self.undo_changes)
 
-        menu.exec_(self.versions_list.mapToGlobal(pos))
+        menu.exec_(self.versions_tree.mapToGlobal(pos))
 
-    def version_details(self, version):
+    def version_details(self, data):
         """Shows version information with full view of added/updated/removed files"""
-        with OverrideCursor(Qt.WaitCursor):
-            info = self.mc.project_version_info(self.project_full_name, version)
-
-        dlg = VersionDetailsDialog(info[0])
+        dlg = VersionDetailsDialog(data)
         dlg.exec_()
 
     def view_changes(self, version):
-        """Shows comparison of changes in the version"""
-        with OverrideCursor(Qt.WaitCursor):
-            if not os.path.exists(os.path.join(self.project_path, ".mergin", ".cache", f"v{version}")):
-                info = self.mc.project_info(self.project_full_name, version=f"v{version}")
-                files = [f for f in info["files"] if is_versioned_file(f["path"])]
-                if not files:
-                    QMessageBox.information(
-                        None, "Mergin", "This version does not contain changes in the project layers."
-                    )
-                    return
+        """Initiates download of changesets for the given version if they are not present
+        in the cache. Otherwise use cached changesets to show diff viewer dialog.
+        """
+        if not os.path.exists(os.path.join(self.project_path, ".mergin", ".cache", f"v{version}")):
+            if self.diff_downloader and self.diff_downloader.isRunning():
+                self.diff_downloader.requestInterruption()
 
-                has_history = any("diff" in f for f in files)
-                if not has_history:
-                    QMessageBox.information(
-                        None, "Mergin", "This version does not contain changes in the project layers."
-                    )
-                    return
+            self.diff_downloader = ChangesetsDownloader(self.mc, self.mp, version)
+            self.diff_downloader.finished.connect(lambda msg: self.show_diff_viewer(version, msg))
+            self.diff_downloader.start()
+        else:
+            self.show_diff_viewer(version)
 
-                for f in files:
-                    if "diff" not in f:
-                        continue
-                    file_diffs = self.mc.download_file_diffs(self.project_path, f["path"], [f"v{version}"])
-                    full_gpkg = self.mp.fpath_cache(f["path"], version=f"v{version}")
-                    if not os.path.exists(full_gpkg):
-                        self.mc.download_file(self.project_path, f["path"], full_gpkg, f"v{version}")
+    def show_diff_viewer(self, version, msg=""):
+        """Shows a Diff Viewer dialog with changes made in the specific version.
+        If msg is not empty string, show message box and returns.
+        """
+        if msg != "":
+            QMessageBox.information(None, "Mergin", msg)
+            return
 
         dlg = DiffViewerDialog(version)
         dlg.exec_()
 
     def download_version(self):
+        """Download project files at the specific version"""
         pass
 
     def revert_to_version(self):
+        """Revert project to the specific version"""
         pass
 
     def undo_changes(self):
+        """Undo changes from the specific version"""
         pass

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -294,7 +294,7 @@ class ProjectHistoryDockWidget(QgsDockWidget):
         with OverrideCursor(Qt.WaitCursor):
             info = self.mc.project_version_info(self.project_full_name, version)
 
-        dlg = VersionDetailsDialog(version, info[0])
+        dlg = VersionDetailsDialog(info[0])
         dlg.exec_()
 
     def view_changes(self, version):

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -109,6 +109,10 @@ class ProjectHistoryDockWidget(QgsDockWidget):
 
         self.update_ui()
 
+    def set_mergin_client(self, mc):
+        self.mc = mc
+        self.update_ui()
+
     def update_ui(self):
         if self.mc is None:
             self.info_label.setText("Plugin is not configured.")

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -1,14 +1,84 @@
 import os
+import math
+import json
+from urllib.error import URLError
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon, QStandardItemModel, QStandardItem
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal, QSortFilterProxyModel
 
 from qgis.gui import QgsDockWidget
 
 from .mergin.merginproject import MerginProject
-from .utils import check_mergin_subdirs, icon_path
+from .mergin.utils import int_version
+
+from .utils import check_mergin_subdirs, icon_path, ClientError
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_project_history_dock.ui")
+
+
+class VersionsModel(QStandardItemModel):
+    INT_VERSION = Qt.UserRole + 1
+    VERSION = Qt.UserRole + 2
+    AUTHOR = Qt.UserRole + 3
+    CREATED = Qt.UserRole + 4
+
+    def __init__(self, versions=None):
+        super(VersionsModel, self).__init__()
+        if versions:
+            self.appendVersions(versions)
+
+    def appendVersions(self, versions):
+        for item in self.createItems(versions):
+            self.appendRow(item)
+
+    @staticmethod
+    def createItems(versions):
+        items = []
+        for version in versions:
+            item = QStandardItem(version["name"])
+            item.setData(int_version(version["name"]), VersionsModel.INT_VERSION)
+            item.setData(version["name"], VersionsModel.VERSION)
+            item.setData(version["author"], VersionsModel.AUTHOR)
+            item.setData(version["created"], VersionsModel.CREATED)
+            items.append(item)
+        return items
+
+
+class VersionsFetcher(QThread):
+    """
+    Class to handle fetching paginated list of project versions in background worker thread
+    """
+
+    finished = pyqtSignal(list)
+
+    def __init__(self, mc, project_name, page):
+        """
+        VersionsFetcher constructor
+
+        :param mc: MerginClient instance
+        :param project_name: namespace to filter by
+        :param page: page to fetch
+        """
+        super(VersionsFetcher, self).__init__()
+        self.mc = mc
+        self.project_name = project_name
+        self.page = page
+
+    def isFetchingNextPage(self):
+        return self.page > 1
+
+    def run(self):
+        try:
+            params = {"page": self.page, "per_page": 100, "descending": True}
+            resp = self.mc.get("/v1/project/versions/paginated/{}".format(self.project_name), params)
+            json_resp = json.load(resp)
+            versions = json_resp["versions"]
+            if self.isInterruptionRequested():
+                return
+            self.finished.emit(versions)
+        except (URLError, ClientError) as e:
+            return
 
 
 class ProjectHistoryDockWidget(QgsDockWidget):
@@ -22,6 +92,20 @@ class ProjectHistoryDockWidget(QgsDockWidget):
         self.mc = mc
         self.mp = None
         self.project_path = None
+        self.project_full_name = None
+        self.last_project_version = None
+
+        self.need_to_fetch_next_page = False
+        self.request_page = None
+        self.fetcher = None
+
+        self.model = VersionsModel()
+        self.proxy = QSortFilterProxyModel()
+        self.proxy.setSourceModel(self.model)
+        self.proxy.setSortRole(VersionsModel.INT_VERSION)
+
+        self.versions_list.setModel(self.proxy)
+        self.versions_list.verticalScrollBar().valueChanged.connect(self.on_scrollbar_changed)
 
         self.update_ui()
 
@@ -38,8 +122,54 @@ class ProjectHistoryDockWidget(QgsDockWidget):
 
         self.mp = MerginProject(self.project_path)
         self.stackedWidget.setCurrentIndex(1)
-        # TODO: load project history
+        self.get_project_history()
 
     def set_project(self, project_path):
         self.project_path = project_path
         self.update_ui()
+
+    def get_project_history(self):
+        self.project_full_name = self.mp.metadata["name"]
+        info = self.mc.project_info(self.project_full_name)
+        self.last_project_version = info["version"]
+
+        self.fetch_from_server()
+
+    def on_scrollbar_changed(self, value):
+        if not self.need_to_fetch_next_page:
+            return
+
+        if self.versions_list.verticalScrollBar().maximum() <= value:
+            self.fetch_from_server(fetch_next_page=True)
+
+    def fetch_from_server(self, fetch_next_page=False):
+        if not fetch_next_page:
+            self.request_page = math.ceil(int_version(self.last_project_version) / 100)
+            self.versions_list.clearSelection()
+            self.versions_list.scrollToTop()
+            self.model.clear()
+
+        if self.fetcher and self.fetcher.isRunning():
+            if fetch_next_page and self.fetcher.isFetchingNextPage():
+                # We only want one fetch_next_page request at a time
+                return
+            else:
+                # Let's replace the existing request with the new one
+                self.fetcher.requestInterruption()
+
+        self.fetcher = VersionsFetcher(self.mc, self.project_full_name, self.request_page)
+        self.fetcher.finished.connect(self.handle_server_response)
+        self.fetcher.start()
+
+    def handle_server_response(self, versions):
+        try:
+            last_fetched_version = versions[-1]["name"]
+            if last_fetched_version != "v1":
+                self.request_page = self.request_page - 1
+                self.need_to_fetch_next_page = True
+            else:
+                self.need_to_fetch_next_page = False
+
+            self.model.appendVersions(versions)
+        except KeyError:
+            pass

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -1,0 +1,45 @@
+import os
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtGui import QIcon
+
+from qgis.gui import QgsDockWidget
+
+from .mergin.merginproject import MerginProject
+from .utils import check_mergin_subdirs, icon_path
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_project_history_dock.ui")
+
+
+class ProjectHistoryDockWidget(QgsDockWidget):
+    def __init__(self, mc):
+        QgsDockWidget.__init__(self)
+        self.ui = uic.loadUi(ui_file, self)
+
+        self.filter_btn.setIcon(QIcon(icon_path("filter.svg")))
+        self.view_changes_btn.setIcon(QIcon(icon_path("file-diff.svg")))
+
+        self.mc = mc
+        self.mp = None
+        self.project_path = None
+
+        self.update_ui()
+
+    def update_ui(self):
+        if self.project_path is None:
+            self.info_label.setText("Current project is not saved. Project history is not available.")
+            self.stackedWidget.setCurrentIndex(0)
+            return
+
+        if not check_mergin_subdirs(self.project_path):
+            self.info_label.setText("Current project is not a Mergin project. Project history is not available.")
+            self.stackedWidget.setCurrentIndex(0)
+            return
+
+        self.mp = MerginProject(self.project_path)
+        self.stackedWidget.setCurrentIndex(1)
+        # TODO: load project history
+
+    def set_project(self, project_path):
+        self.project_path = project_path
+        self.update_ui()

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -409,8 +409,9 @@ class ProjectHistoryDockWidget(QgsDockWidget):
                 else:
                     self.need_to_fetch_next_page = False
 
-            self.model.set_current_version(self.mp.version())
+            self.mp = MerginProject(self.project_path)
             self.model.add_versions(versions)
+            self.model.set_current_version(self.mp.version())
         except KeyError:
             pass
 

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -487,7 +487,10 @@ class ProjectHistoryDockWidget(QgsDockWidget):
             return
 
         dlg = DiffViewerDialog(version)
-        dlg.exec_()
+        if dlg.diff_layers:
+            dlg.exec_()
+        else:
+            QMessageBox.information(None, "Mergin", "No changes to the current project layers for this version.")
 
     def download_version(self):
         """Download project files at the specific version"""

--- a/Mergin/project_history_dock.py
+++ b/Mergin/project_history_dock.py
@@ -244,7 +244,6 @@ class ChangesetsDownloader(QThread):
             self.finished.emit("This version does not contain changes in the project layers.")
             return
 
-        change = False
         for f in files:
             if self.isInterruptionRequested():
                 return
@@ -252,17 +251,9 @@ class ChangesetsDownloader(QThread):
             if "diff" not in f:
                 continue
             file_diffs = self.mc.download_file_diffs(self.mp.dir, f["path"], [f"v{self.version}"])
-
-            if len(file_diffs) > 0:
-                change = True
-
             full_gpkg = self.mp.fpath_cache(f["path"], version=f"v{self.version}")
             if not os.path.exists(full_gpkg):
                 self.mc.download_file(self.mp.dir, f["path"], full_gpkg, f"v{self.version}")
-
-        if not change:
-            self.finished.emit("No changes to the current project layers for this version.")
-            return
 
         self.finished.emit("")
 

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -157,7 +157,7 @@ class MerginProjectsManager(object):
 
         try:
             mp = MerginProject(project_dir)
-            project_name = mp.metadata["name"]
+            project_name = mp.project_full_name()
         except InvalidProject as e:
             msg = f"Failed to get project status:\n\n{str(e)}"
             QMessageBox.critical(None, "Project status", msg, QMessageBox.Close)
@@ -223,7 +223,7 @@ class MerginProjectsManager(object):
         if project_name is None:
             mp = MerginProject(project_dir)
             try:
-                project_name = mp.metadata["name"]
+                project_name = mp.project_full_name()
             except InvalidProject as e:
                 msg = f"Failed to sync project:\n\n{str(e)}"
                 QMessageBox.critical(None, "Project syncing", msg, QMessageBox.Close)

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -16,7 +16,14 @@ from qgis.core import (
 )
 
 from qgis.testing import start_app, unittest
-from Mergin.utils import same_schema, get_datum_shift_grids, is_valid_name, create_tracking_layer, format_size
+from Mergin.utils import (
+    same_schema,
+    get_datum_shift_grids,
+    is_valid_name,
+    create_tracking_layer,
+    format_size,
+    datetime_to_contextual_date,
+)
 
 test_data_path = os.path.join(os.path.dirname(__file__), "data")
 
@@ -207,6 +214,17 @@ class test_utils(unittest.TestCase):
         self.assertEqual(format_size(42580724), "40.61 MiB")
         self.assertEqual(format_size(16242182039), "15.13 GiB")
         self.assertEqual(format_size(5613973017836), "5.106 TiB")
+
+    def test_contextual_date(self):
+        self.assertEqual(contextual_date("2023-11-01T16:09:23Z", "2023-11-01T16:09:34Z"), "just now")
+        self.assertEqual(contextual_date("2023-11-01T16:09:23Z", "2023-11-01T16:10:34Z"), "1 minute ago")
+        self.assertEqual(contextual_date("2023-11-01T16:09:23Z", "2023-11-01T16:31:34Z"), "22 minutes ago")
+        self.assertEqual(contextual_date("2023-11-01T16:09:23Z", "2023-11-01T17:01:34Z"), "52 minutes ago")
+        self.assertEqual(contextual_date("2023-10-31T12:40:23Z", "2023-11-01T16:09:34Z"), "1 day ago")
+        self.assertEqual(contextual_date("2023-10-26T13:01:19Z", "2023-11-01T16:09:34Z"), "6 days ago")
+        self.assertEqual(contextual_date("2023-10-10T13:01:19Z", "2023-11-01T16:09:34Z"), "3 weeks ago")
+        self.assertEqual(contextual_date("2023-09-30T13:01:19Z", "2023-11-01T16:09:34Z"), "1 month ago")
+        self.assertEqual(contextual_date("2023-04-27T06:01:34Z", "2023-11-01T16:09:34Z"), "6 months ago")
 
 
 if __name__ == "__main__":

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -22,7 +22,7 @@ from Mergin.utils import (
     is_valid_name,
     create_tracking_layer,
     format_size,
-    datetime_to_contextual_date,
+    contextual_date,
 )
 
 test_data_path = os.path.join(os.path.dirname(__file__), "data")

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -207,7 +207,7 @@ class test_utils(unittest.TestCase):
     def test_format_size(self):
         self.assertEqual(format_size(0), "0 bytes")
         self.assertEqual(format_size(1), "1 byte")
-        self.assertEqual(format_size(61), "1 bytes")
+        self.assertEqual(format_size(61), "61 bytes")
         self.assertEqual(format_size(5127), "5.007 KiB")
         self.assertEqual(format_size(37700), "36.82 KiB")
         self.assertEqual(format_size(342383), "334.4 KiB")

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -16,7 +16,7 @@ from qgis.core import (
 )
 
 from qgis.testing import start_app, unittest
-from Mergin.utils import same_schema, get_datum_shift_grids, is_valid_name, create_tracking_layer
+from Mergin.utils import same_schema, get_datum_shift_grids, is_valid_name, create_tracking_layer, format_size
 
 test_data_path = os.path.join(os.path.dirname(__file__), "data")
 
@@ -196,6 +196,17 @@ class test_utils(unittest.TestCase):
             self.assertEqual(fields[3].type(), QVariant.Double)
             self.assertEqual(fields[4].name(), "tracked_by")
             self.assertEqual(fields[4].type(), QVariant.String)
+
+    def test_format_size(self):
+        self.assertEqual(format_size(0), "0 bytes")
+        self.assertEqual(format_size(1), "1 byte")
+        self.assertEqual(format_size(61), "1 bytes")
+        self.assertEqual(format_size(5127), "5.007 KiB")
+        self.assertEqual(format_size(37700), "36.82 KiB")
+        self.assertEqual(format_size(342383), "334.4 KiB")
+        self.assertEqual(format_size(42580724), "40.61 MiB")
+        self.assertEqual(format_size(16242182039), "15.13 GiB")
+        self.assertEqual(format_size(5613973017836), "5.106 TiB")
 
 
 if __name__ == "__main__":

--- a/Mergin/ui/ui_project_history_dock.ui
+++ b/Mergin/ui/ui_project_history_dock.ui
@@ -36,7 +36,7 @@
     <item>
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="page">
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -55,7 +55,11 @@
       <widget class="QWidget" name="page_2">
        <layout class="QGridLayout" name="gridLayout">
         <item row="1" column="0" colspan="2">
-         <widget class="QListView" name="versions_list"/>
+         <widget class="QListView" name="versions_list">
+          <property name="contextMenuPolicy">
+           <enum>Qt::CustomContextMenu</enum>
+          </property>
+         </widget>
         </item>
         <item row="0" column="0">
          <widget class="QPushButton" name="filter_btn">

--- a/Mergin/ui/ui_project_history_dock.ui
+++ b/Mergin/ui/ui_project_history_dock.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProjectHistoryDockWidget</class>
+ <widget class="QDockWidget" name="ProjectHistoryDockWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>370</width>
+    <height>450</height>
+   </rect>
+  </property>
+  <property name="allowedAreas">
+   <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
+  </property>
+  <property name="windowTitle">
+   <string>Project history</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout_2">
+    <property name="spacing">
+     <number>0</number>
+    </property>
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QStackedWidget" name="stackedWidget">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="page">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="info_label">
+          <property name="text">
+           <string>Current project is not a Mergin project. Project history is not available.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="page_2">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="0" colspan="2">
+         <widget class="QListView" name="versions_list"/>
+        </item>
+        <item row="0" column="0">
+         <widget class="QPushButton" name="filter_btn">
+          <property name="text">
+           <string>Filter</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="view_changes_btn">
+          <property name="text">
+           <string>View changes</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Mergin/ui/ui_project_history_dock.ui
+++ b/Mergin/ui/ui_project_history_dock.ui
@@ -14,7 +14,7 @@
    <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
   </property>
   <property name="windowTitle">
-   <string>Project history</string>
+   <string>Mergin Maps history</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -55,20 +55,16 @@
       <widget class="QWidget" name="page_2">
        <layout class="QGridLayout" name="gridLayout">
         <item row="1" column="0" colspan="2">
-         <widget class="QListView" name="versions_list">
+         <widget class="QTreeView" name="versions_tree">
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QPushButton" name="filter_btn">
-          <property name="text">
-           <string>Filter</string>
+          <property name="rootIsDecorated">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item row="0" column="0" colspan="2">
          <widget class="QPushButton" name="view_changes_btn">
           <property name="text">
            <string>View changes</string>

--- a/Mergin/ui/ui_version_details_dialog.ui
+++ b/Mergin/ui/ui_version_details_dialog.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Version Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="tree_details">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="headerHidden">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Mergin/ui/ui_version_details_dialog.ui
+++ b/Mergin/ui/ui_version_details_dialog.ui
@@ -6,15 +6,85 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>401</width>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Version Details</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Version</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="edit_version">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Author</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="edit_author">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Project size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="edit_project_size">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Created</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="edit_created">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>User Agent</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="edit_user_agent">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
     <widget class="QTreeView" name="tree_details">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
@@ -27,7 +97,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="6" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -13,6 +13,7 @@ import tempfile
 import json
 import glob
 import re
+import math
 
 from qgis.PyQt.QtCore import QSettings, QVariant
 from qgis.PyQt.QtWidgets import QMessageBox, QFileDialog
@@ -1479,3 +1480,21 @@ def set_tracking_layer_flags(layer):
     """
     layer.setReadOnly(False)
     layer.setFlags(QgsMapLayer.LayerFlag(QgsMapLayer.Identifiable + QgsMapLayer.Searchable + QgsMapLayer.Removable))
+
+
+def format_size(size):
+    """Formats size in bytes into a human-readable size string"""
+    if size == 0:
+        return "0 bytes"
+    if size == 1:
+        return "1 byte"
+
+    units = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+    order = int(math.log2(size) / 10.0)
+    return f"{size / (1 << (order * 10)):.4g} {units[order]}"
+
+
+def format_datetime(date_string):
+    """Formats datetime string returned by the server into human-readable format"""
+    dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
+    return dt.strftime("%a, %d %b %Y %H:%M:%S GMT")

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1498,3 +1498,33 @@ def format_datetime(date_string):
     """Formats datetime string returned by the server into human-readable format"""
     dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
     return dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+
+def contextual_date(date_string, start_date=None):
+    """Converts datetime string returned by the server into contextual duration string, e.g.
+    'N hours/days/month ago'
+    """
+    dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
+    now = datetime.now() if start_date is None else datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%SZ")
+    delta = now - dt
+    if delta.days > 365:
+        years = now.year - dt.year - ((now.month, now.day) < (dt.month, dt.day))
+        return f"{years} {'years' if years > 1 else 'year'} ago"
+    elif delta.days > 31:
+        months = int(delta.days // 30.436875)
+        return f"{months} {'months' if months > 1 else 'month'} ago"
+    elif delta.days > 6:
+        weeks = int(delta.days // 7)
+        return f"{weeks} {'weeks' if weeks > 1 else 'week'} ago"
+
+    if delta.days < 1:
+        hours = delta.seconds // 3600
+        if hours < 1:
+            minutes = (delta.seconds // 60) % 60
+            if minutes <= 0:
+                return "just now"
+            return f"{minutes} {'minutes' if minutes > 1 else 'minute'} ago"
+
+        return f"{hours} {'hours' if hours > 1 else 'hour'} ago"
+
+    return f"{delta.days} {'days' if delta.days > 1 else 'day'} ago"

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1505,7 +1505,7 @@ def contextual_date(date_string, start_date=None):
     'N hours/days/month ago'
     """
     dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
-    now = datetime.now() if start_date is None else datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%SZ")
+    now = datetime.utcnow() if start_date is None else datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%SZ")
     delta = now - dt
     if delta.days > 365:
         years = now.year - dt.year - ((now.month, now.day) < (dt.month, dt.day))

--- a/Mergin/version_details_dialog.py
+++ b/Mergin/version_details_dialog.py
@@ -1,0 +1,69 @@
+import os
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog
+from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
+
+from qgis.gui import QgsGui
+
+from .utils import is_versioned_file, icon_path
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_version_details_dialog.ui")
+
+
+class VersionDetailsDialog(QDialog):
+    icons = {
+        "added": "plus.svg",
+        "removed": "trash.svg",
+        "updated": "pencil.svg",
+        "renamed": "pencil.svg",
+        "table": "table.svg",
+    }
+
+    def __init__(self, version, version_details, parent=None):
+        QDialog.__init__(self, parent)
+        self.ui = uic.loadUi(ui_file, self)
+        QgsGui.instance().enableAutoGeometryRestore(self)
+
+        self.version = version
+        self.version_details = version_details
+
+        self.model = QStandardItemModel()
+        self.model.setHorizontalHeaderLabels(["Details"])
+        self.tree_details.setModel(self.model)
+        self.populate_details()
+        self.tree_details.expandAll()
+
+    def populate_details(self):
+        root_item = QStandardItem(f"Changes in version v{self.version}")
+        self.model.appendRow(root_item)
+        for category in self.version_details["changes"]:
+            for item in self.version_details["changes"][category]:
+                path = item["path"]
+                item = self._get_icon_item(category, path)
+                if is_versioned_file(path):
+                    if path in self.version_details["changesets"]:
+                        for sub_item in self._versioned_file_summary_items(
+                            self.version_details["changesets"][path]["summary"]
+                        ):
+                            item.appendRow(sub_item)
+                root_item.appendRow(item)
+
+    def _get_icon_item(self, key, text):
+        path = icon_path(self.icons[key])
+        item = QStandardItem(text)
+        item.setIcon(QIcon(path))
+        return item
+
+    def _versioned_file_summary_items(self, summary):
+        items = []
+        for s in summary:
+            table_name_item = self._get_icon_item("table", s["table"])
+            for row in self._table_summary_items(s):
+                table_name_item.appendRow(row)
+            items.append(table_name_item)
+
+        return items
+
+    def _table_summary_items(self, summary):
+        return [QStandardItem("{}: {}".format(k, summary[k])) for k in summary if k != "table"]

--- a/Mergin/version_details_dialog.py
+++ b/Mergin/version_details_dialog.py
@@ -6,7 +6,7 @@ from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from qgis.gui import QgsGui
 
-from .utils import is_versioned_file, icon_path
+from .utils import is_versioned_file, icon_path, format_size, format_datetime
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_version_details_dialog.ui")
 
@@ -20,12 +20,11 @@ class VersionDetailsDialog(QDialog):
         "table": "table.svg",
     }
 
-    def __init__(self, version, version_details, parent=None):
+    def __init__(self, version_details, parent=None):
         QDialog.__init__(self, parent)
         self.ui = uic.loadUi(ui_file, self)
         QgsGui.instance().enableAutoGeometryRestore(self)
 
-        self.version = version
         self.version_details = version_details
 
         self.model = QStandardItemModel()
@@ -35,7 +34,13 @@ class VersionDetailsDialog(QDialog):
         self.tree_details.expandAll()
 
     def populate_details(self):
-        root_item = QStandardItem(f"Changes in version v{self.version}")
+        self.edit_version.setText(self.version_details["name"])
+        self.edit_author.setText(self.version_details["author"])
+        self.edit_project_size.setText(format_size(self.version_details["project_size"]))
+        self.edit_created.setText(format_datetime(self.version_details["created"]))
+        self.edit_user_agent.setText(self.version_details["user_agent"])
+
+        root_item = QStandardItem(f"Changes in version {self.version_details['name']}")
         self.model.appendRow(root_item)
         for category in self.version_details["changes"]:
             for item in self.version_details["changes"][category]:


### PR DESCRIPTION
Add a dock widget with project history. History is loaded from the server in the background thread when dock opens for the first time, then on each sync history is updated with the new information. Local project version is shown in bold.

Versions in the dock have a context menu with two actions:
 - viewing version metadata (author, project size, creation date, user agent, etc) and details (changed tables, number of added/removed/modified records).
 - viewing version changes in the diff viewer dialog. Plugin downloads all necessary changesets in the background thread and then uses them to create a diff. Downloaded files are cached and local files will be used when diff is requested again.

![Peek 2023-11-09 12-36](https://github.com/MerginMaps/qgis-plugin/assets/776954/02553e7e-68ac-41f7-a50f-7f50bf9b1ded)