### PR TITLE
edited MerginRootItem to add support for missing "icon" parameter

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -883,6 +883,7 @@ class MerginRootItem(QgsDataCollectionItem):
         parent=None,
         name="Mergin Maps",
         flag=None,
+        icon=None,
         order=None,
         plugin=None,
     ):
@@ -890,7 +891,7 @@ class MerginRootItem(QgsDataCollectionItem):
         if name != providerKey:
             providerKey = "/Mergin" + name
         QgsDataCollectionItem.__init__(self, parent, name, providerKey)
-        self.setIcon(QIcon(mm_symbol_path()))
+        self.setIcon(QIcon(mm_symbol_path())) if icon is None else self.setIcon(QIcon(icon_path(icon)))
         self.setSortKey(order)
         self.plugin = plugin
         self.project_manager = plugin.manager


### PR DESCRIPTION
This is a proposal to fix issue #559 by adding support to the missing "icon" parameter on class MerginRootItem