### PR TITLE
Better dialog error when trying to create a project with an already existing name and the projects limit hit error.

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -86,6 +86,19 @@ class MerginProjectsManager(object):
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
             self.mc.create_project(full_project_name, is_public)
+        except ClientError as e:
+            QApplication.restoreOverrideCursor()
+            msg= str(e)
+            #User friendly error messages
+            if e.http_error == 409:
+                msg = f"Project with the name {full_project_name} already exists\n Try renaming the project"
+            if e.http_error == 422 and e.server_code == 'ProjectsLimitHit':
+                msg =  ("Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
+                        f"Maximum of projects: {e.server_response["projects_quota"]}"
+                )
+
+            QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
+            return False
         except Exception as e:
             QApplication.restoreOverrideCursor()
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + str(e))

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -12,6 +12,7 @@ from urllib.error import URLError
 from .sync_dialog import SyncDialog
 from .utils import (
     ClientError,
+    ErrorCode,
     InvalidProject,
     get_local_mergin_projects_info,
     LoginError,
@@ -91,8 +92,8 @@ class MerginProjectsManager(object):
             msg = str(e)
             # User friendly error messages
             if e.http_error == 409:
-                msg = f"Project with the name \"{project_name}\" already exists in the workspace \"{namespace}\"\n Try renaming the project"
-            if e.http_error == 422 and e.server_code == "ProjectsLimitHit":
+                msg = f'Project with the name "{project_name}" already exists in the workspace "{namespace}"\n Try renaming the project'
+            if e.http_error == 422 and e.server_code == ErrorCode.ProjectsLimitHit.value:
                 msg = (
                     "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
                     f"Maximum of projects: {e.server_response["projects_quota"]}"

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -24,7 +24,7 @@ from .utils import (
     unsaved_project_check,
     UnsavedChangesStrategy,
     write_project_variables,
-    bytes_to_mb
+    bytes_to_human_size,
 )
 
 from .mergin.merginproject import MerginProject
@@ -100,7 +100,7 @@ class MerginProjectsManager(object):
                     f"Maximum of projects: {e.server_response["projects_quota"]}"
                 )
             elif e.server_code == ErrorCode.StorageLimitHit.value:
-                msg = f"{e.detail}]\nCurrent limit: {bytes_to_mb(dlg.exception.server_response["storage_limit"])} Mb"
+                msg = f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
             return False
@@ -373,7 +373,7 @@ class MerginProjectsManager(object):
                     # To note we check for a string since error in flask doesn't return server error code
                     msg = dlg.exception.detail
                 elif dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
-                    msg = f"{e.detail}]\nCurrent limit: {bytes_to_mb(dlg.exception.server_response["storage_limit"])} Mb"
+                    msg = f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
                 else:
                     msg = str(dlg.exception)
                 QMessageBox.critical(None, "Project sync", "Client error: \n" + msg)

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -91,7 +91,7 @@ class MerginProjectsManager(object):
             msg = str(e)
             # User friendly error messages
             if e.http_error == 409:
-                msg = f"Project with the name {project_name} already exists in the workspace {namespace}\n Try renaming the project"
+                msg = f"Project with the name \"{project_name}\" already exists in the workspace \"{namespace}\"\n Try renaming the project"
             if e.http_error == 422 and e.server_code == "ProjectsLimitHit":
                 msg = (
                     "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -91,7 +91,7 @@ class MerginProjectsManager(object):
             msg = str(e)
             # User friendly error messages
             if e.http_error == 409:
-                msg = f"Project with the name {full_project_name} already exists\n Try renaming the project"
+                msg = f"Project with the name {project_name} already exists in the workspace {namespace}\n Try renaming the project"
             if e.http_error == 422 and e.server_code == "ProjectsLimitHit":
                 msg = (
                     "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -366,7 +366,11 @@ class MerginProjectsManager(object):
             if isinstance(dlg.exception, LoginError):
                 login_error_message(dlg.exception)
             elif isinstance(dlg.exception, ClientError):
-                QMessageBox.critical(None, "Project sync", "Client error: " + str(dlg.exception))
+                # To note we check for a string since error in flask doesn't return server error code
+                if dlg.exception.http_error == 400 and "Another process" in dlg.exception.detail:
+                    QMessageBox.critical(None, "Project sync", "Client error:\n" + dlg.exception.detail)
+                else:
+                    QMessageBox.critical(None, "Project sync", "Client error: " + str(dlg.exception))
             else:
                 unhandled_exception_message(
                     dlg.exception_details(),

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -100,7 +100,9 @@ class MerginProjectsManager(object):
                     f"Maximum of projects: {e.server_response["projects_quota"]}"
                 )
             elif e.server_code == ErrorCode.StorageLimitHit.value:
-                msg = f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
+                msg = (
+                    f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
+                )
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
             return False

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -93,11 +93,11 @@ class MerginProjectsManager(object):
             msg = str(e)
             # User friendly error messages
             if e.http_error == 409:
-                msg = f'Project with the name "{project_name}" already exists in the workspace "{namespace}"\n Try renaming the project'
+                msg = f'Project named "{project_name}" already exists in the workspace "{namespace}".\nPlease try renaming the project.'
             elif e.server_code == ErrorCode.ProjectsLimitHit.value:
                 msg = (
-                    "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
-                    f"Maximum of projects: {e.server_response["projects_quota"]}"
+                    "Maximum number of projects reached. Please upgrade your subscription to create new projects.\n"
+                    f"Projects quota: {e.server_response['projects_quota']}"
                 )
             elif e.server_code == ErrorCode.StorageLimitHit.value:
                 msg = (
@@ -373,7 +373,7 @@ class MerginProjectsManager(object):
             elif isinstance(dlg.exception, ClientError):
                 if dlg.exception.http_error == 400 and "Another process" in dlg.exception.detail:
                     # To note we check for a string since error in flask doesn't return server error code
-                    msg = dlg.exception.detail
+                    msg = "Somebody else is syncing, please try again later"
                 elif dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
                     msg = f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
                 else:

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -88,13 +88,14 @@ class MerginProjectsManager(object):
             self.mc.create_project(full_project_name, is_public)
         except ClientError as e:
             QApplication.restoreOverrideCursor()
-            msg= str(e)
-            #User friendly error messages
+            msg = str(e)
+            # User friendly error messages
             if e.http_error == 409:
                 msg = f"Project with the name {full_project_name} already exists\n Try renaming the project"
-            if e.http_error == 422 and e.server_code == 'ProjectsLimitHit':
-                msg =  ("Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
-                        f"Maximum of projects: {e.server_response["projects_quota"]}"
+            if e.http_error == 422 and e.server_code == "ProjectsLimitHit":
+                msg = (
+                    "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
+                    f"Maximum of projects: {e.server_response["projects_quota"]}"
                 )
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -93,7 +93,7 @@ class MerginProjectsManager(object):
             # User friendly error messages
             if e.http_error == 409:
                 msg = f'Project with the name "{project_name}" already exists in the workspace "{namespace}"\n Try renaming the project'
-            if e.http_error == 422 and e.server_code == ErrorCode.ProjectsLimitHit.value:
+            elif e.http_error == 422 and e.server_code == ErrorCode.ProjectsLimitHit.value:
                 msg = (
                     "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
                     f"Maximum of projects: {e.server_response["projects_quota"]}"

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -99,10 +99,7 @@ class MerginProjectsManager(object):
                     f"Maximum of projects: {e.server_response["projects_quota"]}"
                 )
             elif e.http_error == 422 and e.server_code == ErrorCode.StorageLimitHit.value:
-                msg = (
-                    f"{e.detail}]\n"
-                    f"Current limit: {dlg.exception.server_response["storage_limit"]} Mb"
-                )
+                msg = f"{e.detail}]\nCurrent limit: {dlg.exception.server_response["storage_limit"]} Mb"
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
             return False
@@ -375,11 +372,9 @@ class MerginProjectsManager(object):
                     # To note we check for a string since error in flask doesn't return server error code
                     msg = dlg.exception.detail
                 elif dlg.exception.http_error == 422 and dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
-                    msg = (f"{dlg.exception.detail}\n"
-                           f"Current limit: {dlg.exception.server_response["storage_limit"]} Mb"
-                           )
+                    msg = f"{e.detail}]\nCurrent limit: {dlg.exception.server_response["storage_limit"]} Mb"
                 else:
-                    msg =  str(dlg.exception)
+                    msg = str(dlg.exception)
                 QMessageBox.critical(None, "Project sync", "Client error: \n" + msg)
             else:
                 unhandled_exception_message(

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -93,12 +93,12 @@ class MerginProjectsManager(object):
             # User friendly error messages
             if e.http_error == 409:
                 msg = f'Project with the name "{project_name}" already exists in the workspace "{namespace}"\n Try renaming the project'
-            elif e.http_error == 422 and e.server_code == ErrorCode.ProjectsLimitHit.value:
+            elif e.server_code == ErrorCode.ProjectsLimitHit.value:
                 msg = (
                     "Maximum number of projects is reached. Please upgrade your subscription to create new projects\n"
                     f"Maximum of projects: {e.server_response["projects_quota"]}"
                 )
-            elif e.http_error == 422 and e.server_code == ErrorCode.StorageLimitHit.value:
+            elif e.server_code == ErrorCode.StorageLimitHit.value:
                 msg = f"{e.detail}]\nCurrent limit: {dlg.exception.server_response["storage_limit"]} Mb"
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
@@ -371,7 +371,7 @@ class MerginProjectsManager(object):
                 if dlg.exception.http_error == 400 and "Another process" in dlg.exception.detail:
                     # To note we check for a string since error in flask doesn't return server error code
                     msg = dlg.exception.detail
-                elif dlg.exception.http_error == 422 and dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
+                elif dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
                     msg = f"{e.detail}]\nCurrent limit: {dlg.exception.server_response["storage_limit"]} Mb"
                 else:
                     msg = str(dlg.exception)

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -24,6 +24,7 @@ from .utils import (
     unsaved_project_check,
     UnsavedChangesStrategy,
     write_project_variables,
+    bytes_to_mb
 )
 
 from .mergin.merginproject import MerginProject
@@ -99,7 +100,7 @@ class MerginProjectsManager(object):
                     f"Maximum of projects: {e.server_response["projects_quota"]}"
                 )
             elif e.server_code == ErrorCode.StorageLimitHit.value:
-                msg = f"{e.detail}]\nCurrent limit: {dlg.exception.server_response["storage_limit"]} Mb"
+                msg = f"{e.detail}]\nCurrent limit: {bytes_to_mb(dlg.exception.server_response["storage_limit"])} Mb"
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
             return False
@@ -372,7 +373,7 @@ class MerginProjectsManager(object):
                     # To note we check for a string since error in flask doesn't return server error code
                     msg = dlg.exception.detail
                 elif dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
-                    msg = f"{e.detail}]\nCurrent limit: {dlg.exception.server_response["storage_limit"]} Mb"
+                    msg = f"{e.detail}]\nCurrent limit: {bytes_to_mb(dlg.exception.server_response["storage_limit"])} Mb"
                 else:
                     msg = str(dlg.exception)
                 QMessageBox.critical(None, "Project sync", "Client error: \n" + msg)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -64,7 +64,8 @@ from .mergin.utils import int_version
 from .mergin.merginproject import MerginProject
 
 try:
-    from .mergin.client import MerginClient, ClientError, LoginError, InvalidProject, ServerType
+    from .mergin.common import ClientError, ErrorCode, LoginError, InvalidProject
+    from .mergin.client import MerginClient, ServerType
     from .mergin.client_pull import (
         download_project_async,
         download_project_is_running,

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1505,3 +1505,12 @@ def get_layer_by_path(path):
         safe_file_path = layer_path.split("|")
         if safe_file_path[0] == path:
             return layer
+
+def bytes_to_mb(bytes : int):
+    """
+    Convert bytes to megabytes assuming base of bytes in binary
+    
+    Returns:
+    float: Result in megabytes
+    """
+    return bytes / (2**20)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -60,7 +60,7 @@ from qgis.core import (
     QgsMapLayer,
 )
 
-from .mergin.utils import int_version
+from .mergin.utils import int_version, bytes_to_human_size
 from .mergin.merginproject import MerginProject
 
 try:
@@ -1505,12 +1505,3 @@ def get_layer_by_path(path):
         safe_file_path = layer_path.split("|")
         if safe_file_path[0] == path:
             return layer
-
-def bytes_to_mb(bytes : int):
-    """
-    Convert bytes to megabytes assuming base of bytes in binary
-    
-    Returns:
-    float: Result in megabytes
-    """
-    return bytes / (2**20)


### PR DESCRIPTION
This PR improve the dialog error given to user when trying to create a project and sync project. Instead of giving a dump of the server error we display only the part that matter to the users

So far we handle 
* Project with an already existing name 
* projects limit hit error
* Storage limit error
* Another syncing process running

This PR  also relies on another PR in the mergin python api client (see : MerginMaps/python-api-client/pull/209 )

resolve #599 
resolve #561

Before: 
<img width="376" alt="Capture d’écran before" src="https://github.com/MerginMaps/qgis-plugin/assets/30632058/031aae5d-d26e-4a20-ba77-3dc794bd7ead">
<br>
<img width="377" alt="Capture d’écran before quota" src="https://github.com/MerginMaps/qgis-plugin/assets/30632058/d5dadc18-30b6-49a4-89c1-93f117da9c20">

After: 
![Screenshot from 2024-07-09 15-27-29](https://github.com/MerginMaps/qgis-plugin/assets/30632058/b9a0e4b3-8844-4573-ae78-226ec7dc0cd2)

![Screenshot from 2024-07-09 16-11-00](https://github.com/MerginMaps/qgis-plugin/assets/30632058/26e222c8-2d5a-447e-9b23-00a7e99cbb0a)
