### PR TITLE
Cleanup reference to previous repository name of python-api-client

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -107,13 +107,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: MerginMaps/mergin-py-client
+          repository: MerginMaps/python-api-client
           ref: ${{ env.MERGIN_CLIENT_VER }}
-          path: mergin-py-client
+          path: python-api-client
 
       - name: prepare py-client dependencies
         run: |
-          cd mergin-py-client
+          cd python-api-client
           python3 setup.py sdist bdist_wheel
           mkdir -p mergin/deps
           # without __init__.py the deps dir may get recognized as "namespace package" in python
@@ -128,11 +128,11 @@ jobs:
           rm -rf mergin/deps/pygeodiff.libs
           rm -rf mergin/deps/pygeodiff-*.whl
 
-      - name: check geodiff version in sync with mergin-py-client
+      - name: check geodiff version in sync with python-api-client
         run: |
-          GEODIFF_VER_FROM_CLIENT="$(geodiff="$(cat mergin-py-client/mergin_client.egg-info/requires.txt | grep pygeodiff)";echo ${geodiff#pygeodiff==})"
+          GEODIFF_VER_FROM_CLIENT="$(geodiff="$(cat python-api-client/mergin_client.egg-info/requires.txt | grep pygeodiff)";echo ${geodiff#pygeodiff==})"
           if [ "$GEODIFF_VER" != "$GEODIFF_VER_FROM_CLIENT" ]; then
-            echo "geodiff version defined in mergin-py-client requires.txt $GEODIFF_VER_FROM_CLIENT does not equal $GEODIFF_VER from the workpackage file"
+            echo "geodiff version defined in python-api-client requires.txt $GEODIFF_VER_FROM_CLIENT does not equal $GEODIFF_VER from the workpackage file"
             exit 1; # or just warning??
           fi
 
@@ -143,7 +143,7 @@ jobs:
 
       - name: include pygeodiff deps
         run: |
-          cp pygeodiff-binaries/* mergin-py-client/mergin/deps/pygeodiff
+          cp pygeodiff-binaries/* python-api-client/mergin/deps/pygeodiff
 
       - uses: actions/checkout@v3
         with:
@@ -151,7 +151,7 @@ jobs:
 
       - name: create package
         run: |
-          cp -r mergin-py-client/mergin qgis-mergin-plugin/Mergin
+          cp -r python-api-client/mergin qgis-mergin-plugin/Mergin
           rsync -av --exclude='test' --exclude='/__pycache__/' --exclude='*/__pycache__/' qgis-mergin-plugin/Mergin output
           # from 1 June 2024, plugins are required to include LICENSE file
           cp qgis-mergin-plugin/LICENSE.txt output/Mergin/LICENSE

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Checkout client code
         uses: actions/checkout@v3
         with:
-          repository: MerginMaps/mergin-py-client
+          repository: MerginMaps/python-api-client
           ref: ${{ env.MERGIN_CLIENT_VER }}
           path: client
 
-      - name: Install mergin-py-client dependencies
+      - name: Install python-api-client dependencies
         run: |
           pip3 install python-dateutil pytz wheel
           cd client

--- a/docs/dev-docs.md
+++ b/docs/dev-docs.md
@@ -1,7 +1,7 @@
 
 # Developer's documentation
 ## Development/Testing
-Download python [client](https://github.com/MerginMaps/mergin-py-client), install deps and
+Download python [client](https://github.com/MerginMaps/python-api-client), install deps and
 link to qgis plugin:
 ```
     ln -s <path-to-py-client>/mergin/ <path-to-mergin-qgis-plugin>/Mergin/mergin


### PR DESCRIPTION
Changes all previous reference to the current repository to `python-api-client` instead of `mergin-py-client`

Most of the changes are in the actions

No functional changes, but let's wait for the tests in case
