### PR TITLE
Bump version of mergin client and geodiff in actions workflow

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,7 +1,7 @@
 name: Build Mergin Plugin Packages
 env:
-  MERGIN_CLIENT_VER: "0.9.2"
-  GEODIFF_VER: "2.0.2"
+  MERGIN_CLIENT_VER: "0.9.3"
+  GEODIFF_VER: "2.0.4"
   PYTHON_VER: "38"
   PLUGIN_NAME: Mergin
 

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -3,7 +3,7 @@ name: Run Mergin Plugin Tests
 on: [push]
 
 env:
-  MERGIN_CLIENT_VER: "0.8.0"
+  MERGIN_CLIENT_VER: "master"
   PLUGIN_NAME: Mergin
   TEST_FUNCTION: suite.test_all
   DOCKER_IMAGE: qgis/qgis


### PR DESCRIPTION
**packaging**  
Bump version of mergin client and geodiff to latest in the packaging workflow

**auto test** 
Bump version of mergin client to `master` in the testing workflow

### For future 

This PR solve the issue in the short term since there was a python api client release but  I think we should do the packaging on master as well ,  and have a separate workflow for release using only latest released version of dependancies 