### PR TITLE
Enable packaging and test workflows to be triggered mannually with custom inputs  

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,19 +3,19 @@ on:
   push:
   workflow_dispatch:
     inputs:
-      API_CLIENT_VER:
-        description: 'Mergin client version either a tag, release, or branch'
+      PYTHON_API_CLIENT_VER:
+        description: 'python-api-client version: either a tag, release, or a branch'
         required: true
         default: 'master'
         type: string
-      LIB_GEODIFF_VER:
+      GEODIFF_VER:
         description: 'Geodiff version released on PyPI repository'
         default: '2.0.4'
         type: string
 env:
   # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
-  MERGIN_CLIENT_VER: ${{ inputs.API_CLIENT_VER != '' && inputs.API_CLIENT_VER || '0.9.3' }}
-  GEODIFF_VER:  ${{ inputs.LIB_GEODIFF_VER != '' && inputs.LIB_GEODIFF_VER || '2.0.4' }}
+  PYTHON_API_CLIENT_VER: ${{ inputs.PYTHON_API_CLIENT_VER != '' && inputs.PYTHON_API_CLIENT_VER || '0.9.3' }}
+  GEODIFF_VER:  ${{ inputs.GEODIFF_VER != '' && inputs.GEODIFF_VER || '2.0.4' }}
   PYTHON_VER: "38"
   PLUGIN_NAME: Mergin  
 jobs:
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: MerginMaps/mergin-py-client
-          ref: ${{ env.MERGIN_CLIENT_VER }}
+          ref: ${{ env.PYTHON_API_CLIENT_VER }}
           path: mergin-py-client
 
       - name: prepare py-client dependencies

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,19 +3,19 @@ on:
   push:
   workflow_dispatch:
     inputs:
-      MERGIN_CLIENT_VER:
+      API_CLIENT_VER:
         description: 'Mergin client version either a tag, release, or branch'
         required: true
         default: 'master'
         type: string
-      GEODIFF_VER:
+      LIB_GEODIFF_VER:
         description: 'Geodiff version released on PyPI repository'
         default: '2.0.4'
         type: string
 env:
   # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
-  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER || '0.9.3' }}
-  GEODIFF_VER:  ${{ inputs.GEODIFF_VER != '' && inputs.GEODIFF_VER || '2.0.4' }}
+  MERGIN_CLIENT_VER: ${{ inputs.API_CLIENT_VER != '' && inputs.API_CLIENT_VER || '0.9.3' }}
+  GEODIFF_VER:  ${{ inputs.LIB_GEODIFF_VER != '' && inputs.LIB_GEODIFF_VER || '2.0.4' }}
   PYTHON_VER: "38"
   PLUGIN_NAME: Mergin  
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -14,6 +14,7 @@ on:
         default: '2.0.4'
         type: string
 env:
+  # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
   MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| '0.9.3' }}
   GEODIFF_VER:  ${{ inputs.GEODIFF_VER != '' && inputs.GEODIFF_VER|| '2.0.4' }}
   PYTHON_VER: "38"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,28 +1,23 @@
 name: Build Mergin Plugin Packages
-env:
-  MERGIN_CLIENT_VER: "0.9.3"
-  GEODIFF_VER: "2.0.4"
-  PYTHON_VER: "38"
-  PLUGIN_NAME: Mergin
-
 on:
   push:
   workflow_dispatch:
     inputs:
-      logLevel:
-        description: 'Log level'
+      MERGIN_CLIENT_VER:
+        description: 'Mergin client version either a tag, release, or branch'
         required: true
-        default: 'warning'
-        type: choice
-        options:
-          - info
-          - warning
-          - debug
-      tags:
-        description: 'Test scenario tags'
-        required: true
+        default: 'master'
         type: string
-  
+      GEODIFF_VER:
+        description: 'Geodiff version either a tag, release or branch'
+        required: true
+        default: 'master'
+        type: string
+env:
+  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| '0.9.3' }}
+  GEODIFF_VER:  ${{ inputs.GEODIFF_VER != '' && inputs.GEODIFF_VER|| '2.0.4' }}
+  PYTHON_VER: "38"
+  PLUGIN_NAME: Mergin  
 jobs:
   build_linux_binary:
     name: Extract geodiff binary linux

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -9,9 +9,9 @@ on:
         default: 'master'
         type: string
       GEODIFF_VER:
-        description: 'Geodiff version either a tag, release or branch'
+        description: 'Geodiff version released on PyPI repository'
         required: true
-        default: 'master'
+        default: '2.0.4'
         type: string
 env:
   MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| '0.9.3' }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -6,6 +6,7 @@ env:
   PLUGIN_NAME: Mergin
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       logLevel:
@@ -17,10 +18,6 @@ on:
           - info
           - warning
           - debug
-      print_tags:
-        description: 'True to print to STDOUT'
-        required: true
-        type: boolean
       tags:
         description: 'Test scenario tags'
         required: true

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,7 +5,31 @@ env:
   PYTHON_VER: "38"
   PLUGIN_NAME: Mergin
 
-on: [push]
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+      print_tags:
+        description: 'True to print to STDOUT'
+        required: true
+        type: boolean
+      tags:
+        description: 'Test scenario tags'
+        required: true
+        type: string
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
+  
 jobs:
   build_linux_binary:
     name: Extract geodiff binary linux

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,13 +10,12 @@ on:
         type: string
       GEODIFF_VER:
         description: 'Geodiff version released on PyPI repository'
-        required: true
         default: '2.0.4'
         type: string
 env:
   # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
-  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| '0.9.3' }}
-  GEODIFF_VER:  ${{ inputs.GEODIFF_VER != '' && inputs.GEODIFF_VER|| '2.0.4' }}
+  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER || '0.9.3' }}
+  GEODIFF_VER:  ${{ inputs.GEODIFF_VER != '' && inputs.GEODIFF_VER || '2.0.4' }}
   PYTHON_VER: "38"
   PLUGIN_NAME: Mergin  
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -22,10 +22,6 @@ on:
         description: 'Test scenario tags'
         required: true
         type: string
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: true
   
 jobs:
   build_linux_binary:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 env:
+  # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
   MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| 'master' }}
   PLUGIN_NAME: Mergin
   TEST_FUNCTION: suite.test_all

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -4,15 +4,15 @@ on:
   push:
   workflow_dispatch:
     inputs:
-      API_CLIENT_VER:
-        description: 'Mergin client version either a tag, release, or branch'
+      PYTHON_API_CLIENT_VER:
+        description: 'python-api-client version: either a tag, release, or a branch'
         required: true
         default: 'master'
         type: string
 
 env:
   # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
-  MERGIN_CLIENT_VER: ${{ inputs.API_CLIENT_VER != '' && inputs.API_CLIENT_VER || 'master' }}
+  PYTHON_API_CLIENT_VER: ${{ inputs.PYTHON_API_CLIENT_VER != '' && inputs.PYTHON_API_CLIENT_VER || 'master' }}
   PLUGIN_NAME: Mergin
   TEST_FUNCTION: suite.test_all
   DOCKER_IMAGE: qgis/qgis
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: MerginMaps/mergin-py-client
-          ref: ${{ env.MERGIN_CLIENT_VER }}
+          ref: ${{ env.PYTHON_API_CLIENT_VER }}
           path: client
 
       - name: Install mergin-py-client dependencies

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,9 +1,17 @@
 name: Run Mergin Plugin Tests
 
-on: [push]
+on: 
+  push:
+  workflow_dispatch:
+    inputs:
+      MERGIN_CLIENT_VER:
+        description: 'Mergin client version either a tag, release, or branch'
+        required: true
+        default: 'master'
+        type: string
 
 env:
-  MERGIN_CLIENT_VER: "master"
+  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| 'master' }}
   PLUGIN_NAME: Mergin
   TEST_FUNCTION: suite.test_all
   DOCKER_IMAGE: qgis/qgis

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
-  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER|| 'master' }}
+  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER || 'master' }}
   PLUGIN_NAME: Mergin
   TEST_FUNCTION: suite.test_all
   DOCKER_IMAGE: qgis/qgis

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -4,7 +4,7 @@ on:
   push:
   workflow_dispatch:
     inputs:
-      MERGIN_CLIENT_VER:
+      API_CLIENT_VER:
         description: 'Mergin client version either a tag, release, or branch'
         required: true
         default: 'master'
@@ -12,7 +12,7 @@ on:
 
 env:
   # Assign the version provided by 'workflow_dispatch' if available; otherwise, use the default.
-  MERGIN_CLIENT_VER: ${{ inputs.MERGIN_CLIENT_VER != '' && inputs.MERGIN_CLIENT_VER || 'master' }}
+  MERGIN_CLIENT_VER: ${{ inputs.API_CLIENT_VER != '' && inputs.API_CLIENT_VER || 'master' }}
   PLUGIN_NAME: Mergin
   TEST_FUNCTION: suite.test_all
   DOCKER_IMAGE: qgis/qgis


### PR DESCRIPTION
This PR enable a workflow to be triggered manually with custom inputs using `workflow_dispatch` event.
The packages.yml and run-test.yml workflow are currently supported 

This PR reuse the same workflow used when a commit is  pushed and should remain compatible 

Currently we support the following argument(inputs)
* `PYTHON_API_CLIENT_VER` : For python-api-client you can choice any release, tag or branch
* `GEODIFF_VER`: For geodiff only the version uploaded on  PyPi are supported  

To note, you  can't trigger the workflow from the github web interface since it's not yet on the default branch, to test from the  cli interface, use the following command e.g:

For packaging: 
```
gh workflow run "Build Mergin Plugin Packages" --ref workflow-dispatch -f PYTHON_API_CLIENT_VER="master"
```
For test:
```
gh workflow run "Run Mergin Plugin Tests" --ref workflow-dispatch -f PYTHON_API_CLIENT_VER="project-history"
```