### PR TITLE
Cleanup reference to the old Mergin Map mobile app name in the plugin

### DIFF
--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -50,7 +50,7 @@ changelog=2024.2
   - Fix packaging of rasters (#441)
   - Add warning about unsaved changes in the project before showing local changes (#432)
   <p>2022.5
-  - Add project setting to control snapping in Mergin Maps Input
+  - Add project setting to control snapping in Mergin Maps mobile app
   - Add validations for snapping configuration in Mergin Maps project
   - Fix Processing tools to visualize local changes and changes between two versions of the layer
   <p>2022.4.1
@@ -63,7 +63,7 @@ changelog=2024.2
   - Fix Python error when cancelling sync immediately after it started (#405)
   - Update public server URL following rebranding changes (#417)
   <p>2022.3.2
-  - Add project setting to control photo quality in Mergin Maps Input (#383)
+  - Add project setting to control photo quality in Mergin Maps mobile app (#383)
   - Disable primary keys validation for non-GPKG layers (#401)
   - Fix packaging of raster auxilary files with georeferencing information (#371)
   - Update of icon pack and renaming Mergin to Mergin Maps

--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -50,7 +50,7 @@ changelog=2024.2
   - Fix packaging of rasters (#441)
   - Add warning about unsaved changes in the project before showing local changes (#432)
   <p>2022.5
-  - Add project setting to control snapping in Mergin Maps mobile app
+  - Add project setting to control snapping in the mobile app
   - Add validations for snapping configuration in Mergin Maps project
   - Fix Processing tools to visualize local changes and changes between two versions of the layer
   <p>2022.4.1
@@ -63,7 +63,7 @@ changelog=2024.2
   - Fix Python error when cancelling sync immediately after it started (#405)
   - Update public server URL following rebranding changes (#417)
   <p>2022.3.2
-  - Add project setting to control photo quality in Mergin Maps mobile app (#383)
+  - Add project setting to control photo quality in the mobile app (#383)
   - Disable primary keys validation for non-GPKG layers (#401)
   - Fix packaging of raster auxilary files with georeferencing information (#371)
   - Update of icon pack and renaming Mergin to Mergin Maps

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -59,7 +59,7 @@
           <item row="0" column="0" colspan="4">
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for the mobile app in Mergin Maps project. With selective sync enabled Mergin Maps mobile will not download photos from other surveyors to make synchronisation faster. Check out more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for Mergin Maps mobile in Mergin Maps project. With selective sync enabled the mobile app will not download photos from other surveyors to make synchronisation faster. Check out more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -108,7 +108,7 @@
              <bool>true</bool>
             </property>
             <property name="text">
-             <string>Enable selective sync for mobile app</string>
+             <string>Enable selective sync for the mobile app</string>
             </property>
            </widget>
           </item>
@@ -134,7 +134,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is used by Mergin Maps mobile app when adding pictures to the project (taken from camera or using existing picture from gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is used by the mobile app when adding pictures to the project (taken from camera or using existing picture from gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -166,7 +166,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps mobile app will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, the mobile app will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -59,7 +59,7 @@
           <item row="0" column="0" colspan="4">
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for Input in Mergin Maps project. With selective sync enabled Mergin Maps Input will not download photos from other surveyors to make synchronisation faster. Check out more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for the mobile app in Mergin Maps project. With selective sync enabled Mergin Maps mobile will not download photos from other surveyors to make synchronisation faster. Check out more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -108,7 +108,7 @@
              <bool>true</bool>
             </property>
             <property name="text">
-             <string>Enable selective sync for Input</string>
+             <string>Enable selective sync for mobile app</string>
             </property>
            </widget>
           </item>
@@ -134,7 +134,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is used by Mergin Maps Input when adding pictures to the project (taken from camera or using existing picture from gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is used by Mergin Maps mobile app when adding pictures to the project (taken from camera or using existing picture from gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -166,7 +166,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps mobile app will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1411,7 +1411,7 @@ def prefix_for_relative_path(mode, home_path, target_dir):
 
 def create_tracking_layer(project_path):
     """
-    Creates a GPKG layer for tracking in Input
+    Creates a GPKG layer for tracking in mobile app
     """
     filename = get_unique_filename(os.path.join(project_path, "tracking_layer.gpkg"))
 

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1411,7 +1411,7 @@ def prefix_for_relative_path(mode, home_path, target_dir):
 
 def create_tracking_layer(project_path):
     """
-    Creates a GPKG layer for tracking in mobile app
+    Creates a GPKG layer for tracking in the mobile app
     """
     filename = get_unique_filename(os.path.join(project_path, "tracking_layer.gpkg"))
 

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -341,10 +341,10 @@ class MerginProjectValidator(object):
         if ok:
             enabled = QgsProject.instance().snappingConfig().enabled()
             if not enabled and mode == 2:
-                # snapping in mobile app using QGIS setting is enbaled but QGIS snapping is not activated
+                # snapping in the mobile app using QGIS setting is enbaled but QGIS snapping is not activated
                 self.issues.append(MultipleLayersWarning(Warning.QGIS_SNAPPING_NOT_ENABLED))
             if enabled and mode == 0:
-                # snapping in mobile app using QGIS setting is disabled but project has snapping activated
+                # snapping in the mobile app using QGIS setting is disabled but project has snapping activated
                 self.issues.append(MultipleLayersWarning(Warning.MERGIN_SNAPPING_NOT_ENABLED))
 
     def check_datum_shift_grids(self):
@@ -463,13 +463,13 @@ def warning_display_string(warning_id, url=None):
     elif warning_id == Warning.ATTACHMENT_WRONG_EXPRESSION:
         return "Expression for the default path in the attachment widget configuration might be wrong. <a href='{help_mgr.howto_attachment_widget()}'>Read more.</a>"
     elif warning_id == Warning.QGIS_SNAPPING_NOT_ENABLED:
-        return "Snapping is currently disabled in this QGIS project, it will be thus disabled in Mergin Maps mobile app"
+        return "Snapping is currently disabled in this QGIS project, it will be thus disabled in the mobile app"
     elif warning_id == Warning.MERGIN_SNAPPING_NOT_ENABLED:
-        return "Snapping is currently enabled in this QGIS project, but not enabled in Mergin Maps mobile app"
+        return "Snapping is currently enabled in this QGIS project, but not enabled in the mobile app"
     elif warning_id == Warning.MISSING_DATUM_SHIFT_GRID:
         return "Required datum shift grid is missing, reprojection may not work correctly. <a href='fix_datum_shift_grids'>Fix the issue.</a>"
     elif warning_id == Warning.SVG_NOT_EMBEDDED:
-        return "SVGs used for layer styling are not embedded in the project file, as a result those symbols won't be displayed in Mergin Maps mobile app"
+        return "SVGs used for layer styling are not embedded in the project file, as a result those symbols won't be displayed in the mobile app"
     elif warning_id == Warning.EDITOR_PROJECT_FILE_CHANGE:
         return (
             f"You don't have permission to edit the QGIS project file. Your changes to this file will not be sent to the server. "

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -341,10 +341,10 @@ class MerginProjectValidator(object):
         if ok:
             enabled = QgsProject.instance().snappingConfig().enabled()
             if not enabled and mode == 2:
-                # snapping in Input using QGIS setting is enbaled but QGIS snapping is not activated
+                # snapping in mobile app using QGIS setting is enbaled but QGIS snapping is not activated
                 self.issues.append(MultipleLayersWarning(Warning.QGIS_SNAPPING_NOT_ENABLED))
             if enabled and mode == 0:
-                # snapping in Input using QGIS setting is disabled but project has snapping activated
+                # snapping in mobile app using QGIS setting is disabled but project has snapping activated
                 self.issues.append(MultipleLayersWarning(Warning.MERGIN_SNAPPING_NOT_ENABLED))
 
     def check_datum_shift_grids(self):
@@ -463,13 +463,13 @@ def warning_display_string(warning_id, url=None):
     elif warning_id == Warning.ATTACHMENT_WRONG_EXPRESSION:
         return "Expression for the default path in the attachment widget configuration might be wrong. <a href='{help_mgr.howto_attachment_widget()}'>Read more.</a>"
     elif warning_id == Warning.QGIS_SNAPPING_NOT_ENABLED:
-        return "Snapping is currently disabled in this QGIS project, it will be thus disabled in Mergin Maps Input"
+        return "Snapping is currently disabled in this QGIS project, it will be thus disabled in Mergin Maps mobile app"
     elif warning_id == Warning.MERGIN_SNAPPING_NOT_ENABLED:
-        return "Snapping is currently enabled in this QGIS project, but not enabled in Mergin Maps Input"
+        return "Snapping is currently enabled in this QGIS project, but not enabled in Mergin Maps mobile app"
     elif warning_id == Warning.MISSING_DATUM_SHIFT_GRID:
         return "Required datum shift grid is missing, reprojection may not work correctly. <a href='fix_datum_shift_grids'>Fix the issue.</a>"
     elif warning_id == Warning.SVG_NOT_EMBEDDED:
-        return "SVGs used for layer styling are not embedded in the project file, as a result those symbols won't be displayed in Mergin Maps Input"
+        return "SVGs used for layer styling are not embedded in the project file, as a result those symbols won't be displayed in Mergin Maps mobile app"
     elif warning_id == Warning.EDITOR_PROJECT_FILE_CHANGE:
         return (
             f"You don't have permission to edit the QGIS project file. Your changes to this file will not be sent to the server. "


### PR DESCRIPTION
Cleanup reference to the old name of the Mergin Maps mobile app

The old name was used used :
* in project settings
* Status dialog
* And some comments in the code

![image](https://github.com/user-attachments/assets/e0014041-e0ad-442b-96ce-cfbdacbb1243)

Fix #623