### PR TITLE
Fix 617: Reload project following sync of updated .qgz file on windows

### DIFF
--- a/Mergin/create_project_wizard.py
+++ b/Mergin/create_project_wizard.py
@@ -20,7 +20,6 @@ from .utils import (
     check_mergin_subdirs,
     create_basic_qgis_project,
     find_packable_layers,
-    find_qgis_files,
     package_layer,
     PackagingError,
     save_current_project,

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -715,13 +715,6 @@ class MerginLocalProjectItem(QgsDirectoryItem):
             return
         self.project_manager.project_status(self.path)
 
-    def _reload_project(self):
-        """This will forcefully reload the QGIS project because the project (or its data) may have changed"""
-        qgis_proj_filename = os.path.normpath(QgsProject.instance().fileName())
-        qgis_files = find_qgis_files(self.path)
-        if qgis_proj_filename in qgis_files:
-            iface.addProject(QgsProject.instance().fileName())
-
     def remove_local_project(self):
         if not self.path:
             return

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -717,8 +717,9 @@ class MerginLocalProjectItem(QgsDirectoryItem):
 
     def _reload_project(self):
         """This will forcefully reload the QGIS project because the project (or its data) may have changed"""
+        qgis_proj_filename = os.path.normpath(QgsProject.instance().fileName())
         qgis_files = find_qgis_files(self.path)
-        if QgsProject.instance().fileName() in qgis_files:
+        if qgis_proj_filename in qgis_files:
             iface.addProject(QgsProject.instance().fileName())
 
     def remove_local_project(self):

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -43,7 +43,8 @@ class MerginProjectsManager(object):
         """
         Check if current project is the same as actually operated Mergin project and has some unsaved changes.
         """
-        if QgsProject.instance().fileName() in find_qgis_files(project_dir):
+        qgis_proj_filename = os.path.normpath(QgsProject.instance().fileName())
+        if qgis_proj_filename in find_qgis_files(project_dir):
             check_result = unsaved_project_check()
             return False if check_result == UnsavedChangesStrategy.HasUnsavedChanges else True
         return True  # not a Mergin project
@@ -255,7 +256,7 @@ class MerginProjectsManager(object):
         if not self.check_project_server(project_dir):
             return
 
-        current_project_filename = QgsProject.instance().fileName()
+        current_project_filename = os.path.normpath(QgsProject.instance().fileName())
         current_project_path = os.path.normpath(QgsProject.instance().absolutePath())
         if current_project_path == os.path.normpath(project_dir):
             QgsProject.instance().clear()
@@ -356,7 +357,7 @@ class MerginProjectsManager(object):
         dlg.push_start(self.mc, project_dir, project_name)
         dlg.exec_()  # blocks until success, failure or cancellation
 
-        qgis_proj_filename = QgsProject.instance().fileName()
+        qgis_proj_filename = os.path.normpath(QgsProject.instance().fileName())
         qgis_proj_basename = os.path.basename(qgis_proj_filename)
         qgis_proj_changed = False
         for updated in pull_changes["updated"]:

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -364,7 +364,7 @@ class MerginProjectsManager(object):
                 qgis_proj_changed = True
                 break
         filename_in_files = qgis_proj_filename in find_qgis_files(project_dir)
-        if filename_in_files in find_qgis_files(project_dir) and qgis_proj_changed:
+        if filename_in_files and qgis_proj_changed:
             self.open_project(project_dir)
 
         if dlg.exception:

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -364,8 +364,7 @@ class MerginProjectsManager(object):
             if updated["path"] == qgis_proj_basename:
                 qgis_proj_changed = True
                 break
-        filename_in_files = qgis_proj_filename in find_qgis_files(project_dir)
-        if filename_in_files and qgis_proj_changed:
+        if qgis_proj_filename in find_qgis_files(project_dir) and qgis_proj_changed:
             self.open_project(project_dir)
 
         if dlg.exception:

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -363,7 +363,8 @@ class MerginProjectsManager(object):
             if updated["path"] == qgis_proj_basename:
                 qgis_proj_changed = True
                 break
-        if qgis_proj_filename in find_qgis_files(project_dir) and qgis_proj_changed:
+        filename_in_files = qgis_proj_filename in find_qgis_files(project_dir)
+        if filename_in_files in find_qgis_files(project_dir) and qgis_proj_changed:
             self.open_project(project_dir)
 
         if dlg.exception:

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1026,7 +1026,7 @@ def mergin_project_local_path(project_name=None):
                 proj_path = None
         return proj_path
 
-    qgis_project_path = QgsProject.instance().absolutePath()
+    qgis_project_path = os.path.normpath(QgsProject.instance().absolutePath())
     if not qgis_project_path:
         return None
 


### PR DESCRIPTION
The qgis project was not reloading after a sync on windows when there was only change to the .qgz file

This happened because ` QgsProject.instance().fileName()` &` QgsProject.instance().absolutePath() `returned unix-style path even on windows. This behavior mismatch with the return of e.g `os.path.join` in python. 

This PR fix the is by adding an extra os.path.normpath

Fix #617