### PR TITLE
Rename deprecated enum and method in qt5 to qt6

### DIFF
--- a/Mergin/clone_project_dialog.py
+++ b/Mergin/clone_project_dialog.py
@@ -20,7 +20,7 @@ class CloneProjectDialog(QDialog):
         """
         QDialog.__init__(self)
         self.ui = uic.loadUi(ui_file, self)
-        self.ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+        self.ui.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
         self.ui.buttonBox.accepted.connect(self.accept_dialog)
 
         workspaces = user_info.get("workspaces", None)
@@ -67,11 +67,11 @@ class CloneProjectDialog(QDialog):
                 msg = "Incorrect project name!"
 
         self.ui.edit_project_name.setToolTip(msg)
-        self.ui.buttonBox.button(QDialogButtonBox.Ok).setToolTip(msg)
+        self.ui.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setToolTip(msg)
         has_error = bool(msg)
         self.ui.warningMessageLabel.setVisible(has_error)
         self.ui.warningMessageLabel.setText(msg)
-        self.ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(not has_error)
+        self.ui.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(not has_error)
 
     def accept_dialog(self):
         self.project_name = self.ui.edit_project_name.text()

--- a/Mergin/clone_project_dialog.py
+++ b/Mergin/clone_project_dialog.py
@@ -77,4 +77,4 @@ class CloneProjectDialog(QDialog):
         self.project_name = self.ui.edit_project_name.text()
         self.project_namespace = self.ui.projectNamespace.currentText()
 
-        self.accept()  # this will close the dialog and dlg.exec_() returns True
+        self.accept()  # this will close the dialog and dlg.exec() returns True

--- a/Mergin/collapsible_message_box.py
+++ b/Mergin/collapsible_message_box.py
@@ -13,4 +13,4 @@ class CollapsibleBox(QtWidgets.QWidget):
         msg.setStandardButtons(QMessageBox.Close)
         msg.setDefaultButton(QMessageBox.Close)
         msg.setDetailedText(details)
-        msg.exec_()
+        msg.exec()

--- a/Mergin/collapsible_message_box.py
+++ b/Mergin/collapsible_message_box.py
@@ -9,7 +9,7 @@ class CollapsibleBox(QtWidgets.QWidget):
         msg.setWindowTitle(title)
         msg.setTextFormat(Qt.RichText)
         msg.setText(text)
-        msg.setIcon(QMessageBox.Warning)
+        msg.setIcon(QMessageBox.Icon.Warning)
         msg.setStandardButtons(QMessageBox.Close)
         msg.setDefaultButton(QMessageBox.Close)
         msg.setDetailedText(details)

--- a/Mergin/configuration_dialog.py
+++ b/Mergin/configuration_dialog.py
@@ -79,7 +79,7 @@ class ConfigurationDialog(QDialog):
 
     def check_credentials(self):
         credentials_are_set = bool(self.ui.username.text()) and bool(self.ui.password.text())
-        self.ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(credentials_are_set)
+        self.ui.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(credentials_are_set)
         self.ui.test_connection_btn.setEnabled(credentials_are_set)
 
     def check_master_password(self):

--- a/Mergin/create_project_wizard.py
+++ b/Mergin/create_project_wizard.py
@@ -384,9 +384,9 @@ class PackageLayersTreeView(QTreeView):
         self.expandAll()
         self.header().setStretchLastSection(False)
         self.resizeColumnToContents(0)
-        self.header().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.header().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
 
-        self.setSelectionMode(QAbstractItemView.NoSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
         self.setEditTriggers(QTreeView.NoEditTriggers)
 
         self.clicked.connect(self.model().toggle_item)
@@ -420,7 +420,7 @@ class NewMerginProjectWizard(QWizard):
         self.iface = iface
         self.settings = QSettings()
         self.setWindowTitle("Create new Mergin Maps project")
-        self.setWizardStyle(QWizard.ClassicStyle)
+        self.setWizardStyle(QWizard.WizardStyle.ClassicStyle)
         self.setDefaultProperty("QComboBox", "currentText", QComboBox.currentTextChanged)
         self.project_manager = project_manager
         self.username = user_info["username"]
@@ -438,7 +438,7 @@ class NewMerginProjectWizard(QWizard):
         self.package_page = PackagingPage(parent=self)
         self.setPage(PACK_PAGE, self.package_page)
 
-        self.cancel_btn = self.button(QWizard.CancelButton)
+        self.cancel_btn = self.button(QWizard.WizardButton.CancelButton)
         self.cancel_btn.clicked.connect(self.cancel_wizard)
 
         # these are the variables used by the caller

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -330,7 +330,7 @@ class MerginPlugin:
             "Click on the button below to create one. \n\n"
             "A minimum of one workspace is required to use Mergin Maps."
         )
-        msg_box = QMessageBox(QMessageBox.Critical, "You do not have any workspace", msg, QMessageBox.Close)
+        msg_box = QMessageBox(QMessageBox.Icon.Critical, "You do not have any workspace", msg, QMessageBox.Close)
         create_button = msg_box.addButton("Create workspace", msg_box.ActionRole)
         create_button.clicked.disconnect()
         create_button.clicked.connect(partial(self.open_configured_url, "/workspaces"))

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -293,7 +293,7 @@ class MerginPlugin:
     def configure(self):
         """Open plugin configuration dialog."""
         dlg = ConfigurationDialog()
-        if dlg.exec_():
+        if dlg.exec():
             self.mc = dlg.writeSettings()
             self.on_config_changed()
             self.show_browser_panel()
@@ -321,7 +321,7 @@ class MerginPlugin:
             return
 
         wizard = DbSyncConfigWizard(project_name)
-        if not wizard.exec_():
+        if not wizard.exec():
             return
 
     def show_no_workspaces_dialog(self):
@@ -334,7 +334,7 @@ class MerginPlugin:
         create_button = msg_box.addButton("Create workspace", msg_box.ActionRole)
         create_button.clicked.disconnect()
         create_button.clicked.connect(partial(self.open_configured_url, "/workspaces"))
-        msg_box.exec_()
+        msg_box.exec()
 
     def set_current_workspace(self, workspace):
         """
@@ -449,7 +449,7 @@ class MerginPlugin:
             default_workspace = user_info["username"]
 
         wizard = NewMerginProjectWizard(self.manager, user_info=user_info, default_workspace=default_workspace)
-        if not wizard.exec_():
+        if not wizard.exec():
             return  # cancelled
         if self.has_browser_item():
             # make sure the item has the link between remote and local project we have just added
@@ -474,7 +474,7 @@ class MerginPlugin:
         except:
             pass
 
-        dlg.exec_()
+        dlg.exec()
 
     def switch_workspace(self):
         """Open new Switch workspace dialog"""
@@ -490,7 +490,7 @@ class MerginPlugin:
 
         dlg = WorkspaceSelectionDialog(workspaces)
         dlg.manage_workspaces_clicked.connect(self.open_configured_url)
-        if not dlg.exec_():
+        if not dlg.exec():
             return
 
         workspace = dlg.get_workspace()
@@ -501,7 +501,7 @@ class MerginPlugin:
         dlg = PublicProjectSelectionDialog(self.mc)
         dlg.open_project_clicked.connect(self.manager.open_project)
         dlg.download_project_clicked.connect(self.manager.download_project)
-        dlg.exec_()
+        dlg.exec()
 
     def on_qgis_project_changed(self):
         """
@@ -589,7 +589,7 @@ class MerginPlugin:
                     dlg_diff_viewer.tab_bar.setCurrentIndex(i)
                     break
         dlg_diff_viewer.show()
-        dlg_diff_viewer.exec_()
+        dlg_diff_viewer.exec()
 
     def export_vector_tiles(self):
         selected_layers = self.iface.layerTreeView().selectedLayersRecursive()
@@ -637,7 +637,7 @@ class MerginRemoteProjectItem(QgsDataItem):
         user_info = self.mc.user_info()
 
         dlg = CloneProjectDialog(user_info=user_info, default_workspace=self.project["namespace"])
-        if not dlg.exec_():
+        if not dlg.exec():
             return  # cancelled
         try:
             self.mc.clone_project(self.project_name, dlg.project_name, dlg.project_namespace)
@@ -658,7 +658,7 @@ class MerginRemoteProjectItem(QgsDataItem):
 
     def remove_remote_project(self):
         dlg = RemoveProjectDialog(self.project_name)
-        if dlg.exec_() == QDialog.Rejected:
+        if dlg.exec() == QDialog.Rejected:
             return
 
         try:
@@ -790,7 +790,7 @@ class MerginLocalProjectItem(QgsDirectoryItem):
 
         dlg = CloneProjectDialog(user_info=user_info, default_workspace=self.project["namespace"])
 
-        if not dlg.exec_():
+        if not dlg.exec():
             return  # cancelled
         try:
             self.mc.clone_project(self.project_name, dlg.project_name, dlg.project_namespace)

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -95,7 +95,7 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
 
     def get_sync_dir(self):
         abs_path = QFileDialog.getExistingDirectory(
-            None, "Select directory", self.local_project_dir, QFileDialog.ShowDirsOnly
+            None, "Select directory", self.local_project_dir, QFileDialog.Option.ShowDirsOnly
         )
         if self.local_project_dir not in abs_path:
             return

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -226,7 +226,7 @@ class ProjectStatusDialog(QDialog):
         self.close()
         self.ui.messageBar.pushMessage("Mergin", "No changes found in the project layers.", Qgis.Info)
         dlg_diff_viewer.show()
-        dlg_diff_viewer.exec_()
+        dlg_diff_viewer.exec()
 
     def link_clicked(self, url):
         parsed_url = urlparse(url.toString())

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -60,7 +60,7 @@ class ProjectStatusDialog(QDialog):
             self.btn_sync.setIcon(QIcon(icon_path("refresh.svg")))
             # add sync button with AcceptRole. If dialog accepted we will start
             # sync, otherwise just close status dialog
-            self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
+            self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.ButtonRole.AcceptRole)
 
             self.btn_view_changes.setIcon(QIcon(icon_path("file-diff.svg")))
             self.btn_view_changes.clicked.connect(self.show_changes)
@@ -85,7 +85,7 @@ class ProjectStatusDialog(QDialog):
             info_text = self._get_info_text(has_files_to_replace, has_write_permissions, self.mp.has_unfinished_pull())
             for msg in info_text:
                 lbl = QLabel(msg)
-                lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+                lbl.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
                 lbl.setWordWrap(True)
                 self.ui.messageBar.pushWidget(lbl, Qgis.Warning)
 

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -141,7 +141,7 @@ class MerginProjectsManager(object):
         dlg = SyncDialog()
         dlg.push_start(self.mc, project_dir, full_project_name)
 
-        dlg.exec_()  # blocks until success, failure or cancellation
+        dlg.exec()  # blocks until success, failure or cancellation
 
         if dlg.exception:
             # push failed for some reason
@@ -207,7 +207,7 @@ class MerginProjectsManager(object):
             # Sync button in the status dialog returns QDialog.Accepted
             # and Close button returns QDialog::Rejected, so if dialog was
             # accepted we start sync
-            return_value = dlg.exec_()
+            return_value = dlg.exec()
 
             if return_value == ProjectStatusDialog.Accepted:
                 self.sync_project(project_dir)
@@ -313,7 +313,7 @@ class MerginProjectsManager(object):
         dlg = SyncDialog()
         dlg.pull_start(self.mc, project_dir, project_name)
 
-        dlg.exec_()  # blocks until success, failure or cancellation
+        dlg.exec()  # blocks until success, failure or cancellation
 
         if dlg.exception:
             # pull failed for some reason
@@ -354,7 +354,7 @@ class MerginProjectsManager(object):
 
         dlg = SyncDialog()
         dlg.push_start(self.mc, project_dir, project_name)
-        dlg.exec_()  # blocks until success, failure or cancellation
+        dlg.exec()  # blocks until success, failure or cancellation
 
         qgis_proj_filename = QgsProject.instance().fileName()
         qgis_proj_basename = os.path.basename(qgis_proj_filename)
@@ -472,7 +472,7 @@ class MerginProjectsManager(object):
         msg_box.setTextFormat(Qt.RichText)
         msg_box.setStandardButtons(QMessageBox.Ok)
         msg_box.setText(msg)
-        msg_box.exec_()
+        msg_box.exec()
 
     def resolve_unfinished_pull(self, project_dir, reopen_project=False):
         """
@@ -521,7 +521,7 @@ class MerginProjectsManager(object):
 
         dlg = SyncDialog()
         dlg.download_start(self.mc, target_dir, project_name)
-        dlg.exec_()  # blocks until completion / failure / cancellation
+        dlg.exec()  # blocks until completion / failure / cancellation
         if dlg.exception:
             if isinstance(dlg.exception, (URLError, ValueError)):
                 QgsApplication.messageLog().logMessage("Mergin Maps plugin: " + str(dlg.exception))

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -468,7 +468,7 @@ class MerginProjectsManager(object):
         )
         msg_box = QMessageBox()
         msg_box.setWindowTitle("Conflicts found")
-        msg_box.setIcon(QMessageBox.Warning)
+        msg_box.setIcon(QMessageBox.Icon.Warning)
         msg_box.setTextFormat(Qt.RichText)
         msg_box.setStandardButtons(QMessageBox.Ok)
         msg_box.setText(msg)
@@ -506,7 +506,7 @@ class MerginProjectsManager(object):
         project_name = posixpath.join(project["namespace"], project["name"])  # we need posix path for server API calls
         settings = QSettings()
         last_parent_dir = settings.value("Mergin/lastUsedDownloadDir", str(Path.home()))
-        parent_dir = QFileDialog.getExistingDirectory(None, "Open Directory", last_parent_dir, QFileDialog.ShowDirsOnly)
+        parent_dir = QFileDialog.getExistingDirectory(None, "Open Directory", last_parent_dir, QFileDialog.Option.ShowDirsOnly)
         if not parent_dir:
             return
         settings.setValue("Mergin/lastUsedDownloadDir", parent_dir)

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -506,7 +506,9 @@ class MerginProjectsManager(object):
         project_name = posixpath.join(project["namespace"], project["name"])  # we need posix path for server API calls
         settings = QSettings()
         last_parent_dir = settings.value("Mergin/lastUsedDownloadDir", str(Path.home()))
-        parent_dir = QFileDialog.getExistingDirectory(None, "Open Directory", last_parent_dir, QFileDialog.Option.ShowDirsOnly)
+        parent_dir = QFileDialog.getExistingDirectory(
+            None, "Open Directory", last_parent_dir, QFileDialog.Option.ShowDirsOnly
+        )
         if not parent_dir:
             return
         settings.setValue("Mergin/lastUsedDownloadDir", parent_dir)

--- a/Mergin/remove_project_dialog.py
+++ b/Mergin/remove_project_dialog.py
@@ -17,9 +17,9 @@ class RemoveProjectDialog(QDialog):
             "This action cannot be undone.<br><br>"
             "In order to delete project, enter project name in the field below and click 'Yes'."
         )
-        self.buttonBox.button(QDialogButtonBox.Yes).setEnabled(False)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Yes).setEnabled(False)
 
         self.edit_project_name.textChanged.connect(self.project_name_changed)
 
     def project_name_changed(self, text):
-        self.buttonBox.button(QDialogButtonBox.Yes).setEnabled(self.project_name == text)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Yes).setEnabled(self.project_name == text)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -434,7 +434,7 @@ def get_new_qgis_project_filepath(project_name=None):
     settings = QSettings()
     last_dir = settings.value("Mergin/lastUsedDownloadDir", str(pathlib.Path.home()))
     if project_name is not None:
-        dest_dir = QFileDialog.getExistingDirectory(None, "Destination directory", last_dir, QFileDialog.ShowDirsOnly)
+        dest_dir = QFileDialog.getExistingDirectory(None, "Destination directory", last_dir, QFileDialog.Option.ShowDirsOnly)
         project_file = os.path.abspath(os.path.join(dest_dir, project_name))
     else:
         project_file, filters = QFileDialog.getSaveFileName(
@@ -908,7 +908,7 @@ def unhandled_exception_message(error_details, dialog_title, error_text, log_fil
         "please report the problem</a>."
     )
     box = QMessageBox()
-    box.setIcon(QMessageBox.Critical)
+    box.setIcon(QMessageBox.Icon.Critical)
     box.setWindowTitle(dialog_title)
     box.setText(msg)
     if log_file is None:
@@ -923,7 +923,7 @@ def unhandled_exception_message(error_details, dialog_title, error_text, log_fil
             "and briefly describe the problem to add more context to the diagnostic log."
         )
         box.setDetailedText(error_details)
-        btn = box.addButton("Send logs", QMessageBox.ActionRole)
+        btn = box.addButton("Send logs", QMessageBox.ButtonRole.ActionRole)
         btn.clicked.connect(lambda: send_logs(username, log_file))
     box.exec()
 
@@ -1242,7 +1242,7 @@ def is_dark_theme():
 
     # check whether system-wide theme is dark
     palette = QgsApplication.instance().palette()
-    bg_color = palette.color(QPalette.Window)
+    bg_color = palette.color(QPalette.ColorRole.Window)
     brightness = (bg_color.red() * 299 + bg_color.green() * 587 + bg_color.blue() * 114) / 1000
     return brightness < 155
 

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -925,7 +925,7 @@ def unhandled_exception_message(error_details, dialog_title, error_text, log_fil
         box.setDetailedText(error_details)
         btn = box.addButton("Send logs", QMessageBox.ActionRole)
         btn.clicked.connect(lambda: send_logs(username, log_file))
-    box.exec_()
+    box.exec()
 
 
 def write_project_variables(project_owner, project_name, project_full_name, version, server):

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -434,7 +434,9 @@ def get_new_qgis_project_filepath(project_name=None):
     settings = QSettings()
     last_dir = settings.value("Mergin/lastUsedDownloadDir", str(pathlib.Path.home()))
     if project_name is not None:
-        dest_dir = QFileDialog.getExistingDirectory(None, "Destination directory", last_dir, QFileDialog.Option.ShowDirsOnly)
+        dest_dir = QFileDialog.getExistingDirectory(
+            None, "Destination directory", last_dir, QFileDialog.Option.ShowDirsOnly
+        )
         project_file = os.path.abspath(os.path.join(dest_dir, project_name))
     else:
         project_file, filters = QFileDialog.getSaveFileName(


### PR DESCRIPTION
This PR rename deprecated enum and method in qt5 and that will be removed in qt6. This should make the plugin mostly compatible when QGIS finally does switch to a newer version of qt.

See : https://www.pythonguis.com/faq/pyqt5-vs-pyqt6/

Ideally from now on we should  write code compatible with qt6