### PR TITLE
Script to format python files

### DIFF
--- a/docs/dev-docs.md
+++ b/docs/dev-docs.md
@@ -31,3 +31,12 @@ Now link the plugin to your QGIS profile python:
 
 Plugin packages are built as GitHub actions for every commit.
 When releasing, make sure to check if [run-test.yml](../.github/workflows/run-test.yml) is using the latest QGIS release tag for auto-tests.
+
+## Code Formatting
+
+To format code and pass CI check, you can run `format_py.bash` script.
+
+### Setup:
+1. Install Black: `pip install black`
+2. Make script executable: `chmod +x format_py.bash`
+3. Run script: `./format_py.bash`

--- a/scripts/format_py.bash
+++ b/scripts/format_py.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+black -l 120 ../Mergin


### PR DESCRIPTION
Format Python files in `Mergin` folder using Black code formatter.

Setup:
1. Install Black: `pip install black`
2. Make script executable: `chmod +x format_py.bash`
3. Run script `./format_py.bash`