### PR TITLE
Bump upload-artifact and download-artifact action to v4

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -157,6 +157,7 @@ jobs:
           path: artifact-pygeodiff
           pattern: artifact-pygeodiff-*
           merge-multiple: true
+          delete-merged: true
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -47,7 +47,7 @@ jobs:
           patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so.0 ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./pygeodiff-binaries/*.so
 
@@ -75,7 +75,7 @@ jobs:
           unzip -o pygeodiff-$env:GEODIFF_VER-cp$env:PYTHON_VER-cp$env:PYTHON_VER-win_amd64.whl -d tmp64
           copy tmp64\pygeodiff\*.pyd pygeodiff-binaries\
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./pygeodiff-binaries/*.pyd
 
@@ -109,7 +109,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./pygeodiff-binaries/*.dylib
 
@@ -148,7 +148,7 @@ jobs:
             exit 1; # or just warning??
           fi
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: pygeodiff-binaries
@@ -169,7 +169,12 @@ jobs:
           cp qgis-mergin-plugin/LICENSE.txt output/Mergin/LICENSE
           (cd output && zip -r9 ../mergin.zip Mergin/)
 
-      - uses: actions/upload-artifact@v3
+
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          pattern: ./pygeodiff-binaries/*
+      - uses: actions/upload-artifact@v4
         with:
           name: Mergin
           path: output/

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -150,7 +150,13 @@ jobs:
             echo "geodiff version defined in python-api-client requires.txt $GEODIFF_VER_FROM_CLIENT does not equal $GEODIFF_VER from the workpackage file"
             exit 1; # or just warning??
           fi
-
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          path: artifact-pygeodiff
+          pattern: artifact-pygeodiff-*
+          merge-multiple: true
+          
       - uses: actions/download-artifact@v4
         with:
           name: artifact
@@ -173,12 +179,7 @@ jobs:
           (cd output && zip -r9 ../mergin.zip Mergin/)
 
 
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          path: artifact-pygeodiff
-          pattern: artifact-pygeodiff-*
-          merge-multiple: true
+
       - uses: actions/upload-artifact@v4
         with:
           name: Mergin

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -49,6 +49,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-pygeodiff-linux
           path: ./pygeodiff-binaries/*.so
 
   build_windows_binaries:
@@ -77,6 +78,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-pygeodiff-windows
           path: ./pygeodiff-binaries/*.pyd
 
   build_macos_binary:
@@ -111,6 +113,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-pygeodiff-macos
           path: ./pygeodiff-binaries/*.dylib
 
   create_mergin_plugin_package:
@@ -173,7 +176,9 @@ jobs:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
-          pattern: ./pygeodiff-binaries/*
+          path: artifact-pygeodiff
+          pattern: artifact-pygeodiff-*
+          merge-multiple: true
       - uses: actions/upload-artifact@v4
         with:
           name: Mergin

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -153,10 +153,11 @@ jobs:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
+          name: artifact
           path: artifact-pygeodiff
           pattern: artifact-pygeodiff-*
           merge-multiple: true
-          
+
       - uses: actions/download-artifact@v4
         with:
           name: artifact


### PR DESCRIPTION
Bump upload-artifact and download-artifact action to v4.

Some changes were required in the PR because in  the V4, artifact are immutable once created. You can't incrementally add file to an artifact anymore, we have to use the `actions/upload-artifact/merge@v4` see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts