### PR TITLE
use UK spelling (fix #579)

### DIFF
--- a/Mergin/configure_sync_wizard.py
+++ b/Mergin/configure_sync_wizard.py
@@ -62,10 +62,10 @@ class GpkgSelectionPage(ui_gpkg_select_page, base_gpkg_select_page):
     def initializePage(self):
         direction = self.field("init_from")
         if direction == "gpkg":
-            self.label.setText("Pick a GeoPackage file that contains data to be synchronized")
+            self.label.setText("Pick a GeoPackage file that contains data to be synchronised")
             self.file_edit_gpkg.setStorageMode(QgsFileWidget.GetFile)
         else:
-            self.label.setText("Pick a GeoPackage file that will contain synchronized data")
+            self.label.setText("Pick a GeoPackage file that will contain synchronised data")
             self.file_edit_gpkg.setStorageMode(QgsFileWidget.SaveFile)
 
         self.file_edit_gpkg.setDialogTitle(self.tr("Select file"))

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -776,7 +776,7 @@ class MerginLocalProjectItem(QgsDirectoryItem):
         action_open_project = QAction("Open QGIS project", parent)
         action_open_project.triggered.connect(self.open_project)
 
-        action_sync_project = QAction(QIcon(icon_path("refresh.svg")), "Synchronize", parent)
+        action_sync_project = QAction(QIcon(icon_path("refresh.svg")), "Synchronise", parent)
         action_sync_project.triggered.connect(self.sync_project)
 
         action_clone_remote = QAction(QIcon(icon_path("copy.svg")), "Clone", parent)

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -390,7 +390,7 @@ class MerginProjectsManager(object):
 
         if dlg.is_complete:
             # TODO: report success only when we have actually done anything
-            msg = "Mergin Maps project {} synchronized successfully".format(project_name)
+            msg = "Mergin Maps project {} synchronised successfully".format(project_name)
             QMessageBox.information(None, "Project sync", msg, QMessageBox.Close)
             # clear canvas cache so any changes become immediately visible to users
             self.iface.mapCanvas().clearCache()

--- a/Mergin/ui/ui_gpkg_selection_page.ui
+++ b/Mergin/ui/ui_gpkg_selection_page.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Pick a GeoPackage file that contains data to be synchronized</string>
+      <string>Pick a GeoPackage file that contains data to be synchronised</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
Use UK English spelling "synchronize" → "synchronise".

Fixes #579.