### PR TITLE
Fix component names

### DIFF
--- a/Mergin/processing/algs/create_diff.py
+++ b/Mergin/processing/algs/create_diff.py
@@ -58,7 +58,7 @@ class CreateDiff(QgsProcessingAlgorithm):
         )
 
     def shortHelpString(self):
-        return "Extracts changes made between two versions of the layer of the Mergin project to make it easier to revise changes."
+        return "Extracts changes made between two versions of the layer of the Mergin Maps project to make it easier to revise changes."
 
     def icon(self):
         return QIcon(mm_symbol_path())

--- a/Mergin/processing/algs/extract_local_changes.py
+++ b/Mergin/processing/algs/extract_local_changes.py
@@ -57,7 +57,7 @@ class ExtractLocalChanges(QgsProcessingAlgorithm):
         )
 
     def shortHelpString(self):
-        return "Extracts local changes made in the specific layer of the Mergin project to make it easier to revise changes."
+        return "Extracts local changes made in the specific layer of the Mergin Maps project to make it easier to revise changes."
 
     def icon(self):
         return QIcon(mm_symbol_path())

--- a/Mergin/ui/ui_clone_project.ui
+++ b/Mergin/ui/ui_clone_project.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Clone Mergin Project</string>
+   <string>Clone Mergin Maps Project</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>

--- a/Mergin/ui/ui_config.ui
+++ b/Mergin/ui/ui_config.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Mergin Settings</string>
+   <string>Mergin Maps Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="5" column="0">

--- a/Mergin/ui/ui_sync_dialog.ui
+++ b/Mergin/ui/ui_sync_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Mergin - Synchronization</string>
+   <string>Mergin Maps - Synchronization</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item alignment="Qt::AlignHCenter">


### PR DESCRIPTION
Fix use of old names of Mergin Maps components in various places.

Fixes #572.