### PR TITLE
Handle download error instead of hanging on the loading screen...

### DIFF
--- a/Mergin/ui/ui_versions_viewer.ui
+++ b/Mergin/ui/ui_versions_viewer.ui
@@ -265,7 +265,7 @@
          <item row="3" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
-            <string>Created with:</string>
+            <string>Created with</string>
            </property>
           </widget>
          </item>

--- a/Mergin/version_viewer_dialog.py
+++ b/Mergin/version_viewer_dialog.py
@@ -234,7 +234,6 @@ class ChangesetsDownloader(QThread):
                 self.error_occured.emit(e)
                 return
 
-
         if self.isInterruptionRequested():
             self.quit()
             return
@@ -632,10 +631,12 @@ class VersionViewerDialog(QDialog):
             self.tabWidget.setTabEnabled(0, False)
 
     def show_download_error(self, e: Exception):
-        additional_log = str(e) 
+        additional_log = str(e)
         QgsMessageLog.logMessage(f"Download history error: " + additional_log, "Mergin")
-        self.label_info.setText("There was an issue loading this version. Please try again later or contact our support if the issue persists. Refer to the QGIS messages log for more details.")
-         
+        self.label_info.setText(
+            "There was an issue loading this version. Please try again later or contact our support if the issue persists. Refer to the QGIS messages log for more details."
+        )
+
     def collect_layers(self, checked: bool):
         if checked:
             layers = iface.mapCanvas().layers()


### PR DESCRIPTION
Handle the case where a download request would fail. The UI was updated to avoid hanging on the Loading screen message

I'm looking with MartinV to have a more user friendly error reporting

illustration:

![image](https://github.com/user-attachments/assets/090bd0fd-38fb-4cfd-a565-ef4b5f556b5f)


Partially fix #673