### PR TITLE
Fix 685: History viewer  changes visualisation not working if the geopackage was in a sub folder

### DIFF
--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -357,7 +357,7 @@ def make_version_changes_layers(project_path, version):
 
     layers = []
     version_dir = os.path.join(project_path, ".mergin", ".cache", f"v{version}")
-    for f in glob.iglob(f"{version_dir}/*.gpkg"):
+    for f in glob.iglob(f"{version_dir}/**/*.gpkg", recursive=True):
         gpkg_file = os.path.join(version_dir, f)
         schema_file = gpkg_file + "-schema.json"
         if not os.path.exists(schema_file):
@@ -408,7 +408,7 @@ def make_version_changes_layers(project_path, version):
 
 def find_changeset_file(file_name, version_dir):
     """Returns path to the diff file for the given version file"""
-    for f in glob.iglob(f"{version_dir}/*.gpkg-diff*"):
+    for f in glob.iglob(f"{version_dir}/**/*.gpkg-diff*", recursive=True):
         if f.startswith(file_name):
             return os.path.join(version_dir, f)
     return None


### PR DESCRIPTION
Unless what the ticket said it was not because multiple layer saved in the same geopackage but because the geopackage was in a subfolder.

the search glob would only search for geopackages at the root path of the version downloaded, this PR also search recursively in the directory

Fix #685 