### PR TITLE
Add user friendly display expression for tracking layer

### DIFF
--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1492,7 +1492,9 @@ def setup_tracking_layer(layer: QgsVectorLayer):
     user_default.setExpression("@mergin_username")
     layer.setDefaultValueDefinition(idx, user_default)
 
-    layer.setDisplayExpression('"tracked_by" ||\' on \'|| format_date( "tracking_end_time", \'dd MMM yyyy\') ||\' at \'|| format_date("tracking_end_time", \'H:MM\')')
+    layer.setDisplayExpression(
+        "\"tracked_by\" ||' on '|| format_date( \"tracking_end_time\", 'dd MMM yyyy') ||' at '|| format_date(\"tracking_end_time\", 'H:MM')"
+    )
 
     symbol = QgsLineSymbol.createSimple(
         {

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1462,7 +1462,7 @@ def create_tracking_layer(project_path):
     return filename
 
 
-def setup_tracking_layer(layer):
+def setup_tracking_layer(layer: QgsVectorLayer):
     """
     Configures tracking layer:
      - set default values for fields
@@ -1491,6 +1491,8 @@ def setup_tracking_layer(layer):
     user_default = QgsDefaultValue()
     user_default.setExpression("@mergin_username")
     layer.setDefaultValueDefinition(idx, user_default)
+
+    layer.setDisplayExpression('"tracked_by" ||\' on \'|| format_date( "tracking_end_time", \'dd MMM yyyy\') ||\' at \'|| format_date("tracking_end_time", \'H:MM\')')
 
     symbol = QgsLineSymbol.createSimple(
         {


### PR DESCRIPTION
When a tracking layer is enable we create a default display expression as well 

Looks like this in the mobile app

![Screenshot_20250425_103030.jpg](https://github.com/user-attachments/assets/522c972d-9e04-4221-9901-4cf9f56feabc)



Fix #681