### PR TITLE
Download Vector Tiles process, issue a warning instead of a crash if the request  zoom level is bigger than source layer zoom level

### DIFF
--- a/Mergin/processing/algs/download_vector_tiles.py
+++ b/Mergin/processing/algs/download_vector_tiles.py
@@ -154,8 +154,9 @@ class DownloadVectorTiles(QgsProcessingAlgorithm):
 
         self.max_zoom = self.parameterAsInt(parameters, self.MAX_ZOOM, context)
         if self.max_zoom > layer.sourceMaxZoom():
-            raise QgsProcessingException(
-                f"Requested maximum zoom level is bigger than available zoom level in the source layer. Please, select zoom level lower or equal to {layer.sourceMaxZoom()}."
+            self.max_zoom = layer.sourceMaxZoom()
+            feedback.pushWarning(
+                f"Requested maximum zoom level is bigger than available zoom level in the source layer. Zoom level will be clamped to {layer.sourceMaxZoom()}."
             )
 
         self.tile_limit = self.parameterAsInt(parameters, self.TILE_LIMIT, context)


### PR DESCRIPTION
Small annoyance I found while trying to make a vector tiles layer available offline

The process would crash if the requested zoom level is instead only issue a simple warning and clamp the requested zoom level to the source

See before/after : 
![image psd(1)](https://github.com/user-attachments/assets/ab2e2f8b-f8a8-4e84-b711-027a3b35cc6a)
