### PR TITLE
Deprecate old server version (< 2023)

### DIFF
--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1256,7 +1256,7 @@ def test_server_connection(url, username, password):
             QMessageBox.information(
                 None,
                 "Deprecated server version",
-                "The server is using an older, deprecated version. The support for this version will be removed in the next release, please contact your server administrator.",
+                "This server is running an outdated version that will no longer be supported. Please contact your server administrator to upgrade.",
             )
     except (LoginError, ClientError) as e:
         QgsApplication.messageLog().logMessage(f"Mergin Maps plugin: {str(e)}")

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1250,7 +1250,14 @@ def test_server_connection(url, username, password):
     result = True, "<font color=green> OK </font>"
     proxy_config = get_qgis_proxy_config(url)
     try:
-        MerginClient(url, None, username, password, get_plugin_version(), proxy_config)
+        mc = MerginClient(url, None, username, password, get_plugin_version(), proxy_config)
+
+        if mc.server_type() == ServerType.OLD:
+            QMessageBox.information(
+                None,
+                "Deprecated server version",
+                "The server is using an older, deprecated version. The support for this version will be removed in the next release, please contact your server administrator.",
+            )
     except (LoginError, ClientError) as e:
         QgsApplication.messageLog().logMessage(f"Mergin Maps plugin: {str(e)}")
         result = False, f"<font color=red> Connection failed, {str(e)} </font>"


### PR DESCRIPTION
This PR add a warning for the user if they use a deprecated server version (< 2023). The warning popup appears when testing connection and when connecting 

We will drop support with #689 in the release afterward

![Screenshot From 2025-05-06 12-43-19](https://github.com/user-attachments/assets/a891f792-21bf-48c9-92ee-e10c24e7c526)
