### PR TITLE
Fix crash when adding map sketches on older QGIS release and add a test case

### DIFF
--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -216,7 +216,8 @@ class test_utils(unittest.TestCase):
             dir_name, file_name = os.path.split(file_path)
             self.assertEqual(file_name, "map_sketches.gpkg")
 
-            layer = QgsVectorLayer(file_path, "", "ogr")
+            layer = QgsProject().instance().mapLayersByName("Map sketches")[0]
+
             self.assertTrue(layer.isValid())
             self.assertEqual(layer.wkbType(), QgsWkbTypes.MultiLineStringZM)
 

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -218,7 +218,7 @@ class test_utils(unittest.TestCase):
 
             layer = QgsVectorLayer(file_path, "", "ogr")
             self.assertTrue(layer.isValid())
-            self.assertEqual(layer.wkbType(), QgsWkbTypes.LineStringZM)
+            self.assertEqual(layer.wkbType(), QgsWkbTypes.MultiLineStringZM)
 
             fields = layer.fields()
             self.assertEqual(len(fields), 9)

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -17,10 +17,17 @@ from qgis.core import (
     QgsCoordinateTransformContext,
     QgsVectorLayer,
     QgsWkbTypes,
+    QgsSymbolLayer,
 )
 
 from qgis.testing import start_app, unittest
-from Mergin.utils import same_schema, get_datum_shift_grids, is_valid_name, create_tracking_layer
+from Mergin.utils import (
+    same_schema,
+    get_datum_shift_grids,
+    is_valid_name,
+    create_tracking_layer,
+    create_map_sketches_layer,
+)
 
 test_data_path = os.path.join(os.path.dirname(__file__), "data")
 
@@ -200,6 +207,47 @@ class test_utils(unittest.TestCase):
             self.assertEqual(fields[3].type(), QVariant.Double)
             self.assertEqual(fields[4].name(), "tracked_by")
             self.assertEqual(fields[4].type(), QVariant.String)
+
+    def test_create_map_sketches_layer(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = create_map_sketches_layer(temp_dir)
+
+            self.assertTrue(os.path.exists(file_path))
+            dir_name, file_name = os.path.split(file_path)
+            self.assertEqual(file_name, "map_sketches.gpkg")
+
+            layer = QgsVectorLayer(file_path, "", "ogr")
+            self.assertTrue(layer.isValid())
+            self.assertEqual(layer.wkbType(), QgsWkbTypes.LineStringZM)
+
+            fields = layer.fields()
+            self.assertEqual(len(fields), 9)
+            self.assertEqual(fields[0].name(), "fid")
+            self.assertEqual(fields[1].name(), "color")
+            self.assertEqual(fields[1].type(), QVariant.String)
+            self.assertEqual(fields[2].name(), "author")
+            self.assertEqual(fields[2].type(), QVariant.String)
+            self.assertEqual(fields[3].name(), "created_at")
+            self.assertEqual(fields[3].type(), QVariant.DateTime)
+            self.assertEqual(fields[4].name(), "width")
+            self.assertEqual(fields[4].type(), QVariant.Double)
+            self.assertEqual(fields[5].name(), "attr1")
+            self.assertEqual(fields[5].type(), QVariant.Double)
+            self.assertEqual(fields[6].name(), "attr2")
+            self.assertEqual(fields[6].type(), QVariant.Double)
+            self.assertEqual(fields[7].name(), "attr3")
+            self.assertEqual(fields[7].type(), QVariant.String)
+            self.assertEqual(fields[8].name(), "attr4")
+            self.assertEqual(fields[8].type(), QVariant.String)
+
+            sl = layer.renderer().symbol().symbolLayer(0)
+            self.assertEqual(
+                sl.dataDefinedProperties().property(QgsSymbolLayer.PropertyStrokeColor).expressionString(), '"color"'
+            )
+
+            self.assertEqual(
+                sl.dataDefinedProperties().property(QgsSymbolLayer.PropertyStrokeWidth).expressionString(), '"width"'
+            )
 
 
 if __name__ == "__main__":

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1519,8 +1519,8 @@ def create_map_sketches_layer(project_path):
 
     # get symbol layer and set it to expression for color
     symbol_layer = symbol.takeSymbolLayer(0)
-    symbol_layer.setDataDefinedProperty(QgsSymbolLayer.Property.StrokeColor, QgsProperty.fromExpression('"color"'))
-    symbol_layer.setDataDefinedProperty(QgsSymbolLayer.Property.StrokeWidth, QgsProperty.fromExpression('"width"'))
+    symbol_layer.setDataDefinedProperty(QgsSymbolLayer.PropertyStrokeColor, QgsProperty.fromExpression('"color"'))
+    symbol_layer.setDataDefinedProperty(QgsSymbolLayer.PropertyStrokeWidth, QgsProperty.fromExpression('"width"'))
     # put it back to the symbol
     symbol.appendSymbolLayer(symbol_layer)
 


### PR DESCRIPTION
Fix crash when adding a map sketches layer because we can't use the new fancy enum in older QGIS release.

Also add a test case for this

![image](https://github.com/user-attachments/assets/fb634c68-2b5f-4b8f-b115-362c113fc6de)
