### PR TITLE
Hide map sketches behind the experimental plugin flag

### DIFF
--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -28,6 +28,7 @@ from .utils import (
     create_tracking_layer,
     create_map_sketches_layer,
     set_tracking_layer_flags,
+    is_experimental_plugin_enabled,
 )
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_project_config.ui")
@@ -117,6 +118,12 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         self.attachment_fields.setModel(self.attachments_model)
         self.attachment_fields.selectionModel().currentChanged.connect(self.update_expression_edit)
         self.edit_photo_expression.expressionChanged.connect(self.expression_changed)
+
+        if not is_experimental_plugin_enabled():
+            # Hide by default
+            self.groupBox_map_sketching.setVisible(False)
+        else:
+            self.groupBox_map_sketching.setTitle(self.groupBox_map_sketching.title() + " (Experimental)")
 
     def get_sync_dir(self):
         abs_path = QFileDialog.getExistingDirectory(

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -44,9 +44,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-612</y>
+        <y>-766</y>
         <width>628</width>
-        <height>1168</height>
+        <height>1322</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -318,7 +318,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="groupBox_map_sketching">
          <property name="title">
           <string>Map sketching</string>
          </property>

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1696,6 +1696,7 @@ def duplicate_layer(layer: QgsVectorLayer) -> QgsVectorLayer:
     return lyr_clone
 
 
-def is_experimental_plugin_enabled():
+def is_experimental_plugin_enabled() -> bool:
+    """Returns True if the experimental flag is enable in the plugin manager else false"""
     settings = QSettings()
     return settings.value("plugin-manager/allow-experimental", False)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1694,3 +1694,8 @@ def duplicate_layer(layer: QgsVectorLayer) -> QgsVectorLayer:
         raise Exception(err_msg)
 
     return lyr_clone
+
+
+def is_experimental_plugin_enabled():
+    settings = QSettings()
+    return settings.value("plugin-manager/allow-experimental", False)


### PR DESCRIPTION
This PR hides the map sketches, based on the experimental flag in the plugin manager. 

![image](https://github.com/user-attachments/assets/59d509f2-5efe-4f52-88de-6edf193e4c3d)


if enable the map sketches shows up with the `(Experimental)` title added
![image](https://github.com/user-attachments/assets/08623aed-0a97-4e9b-b9e6-7e59d81e2975)


if not enabled the map sketches settings don't shows up

![image](https://github.com/user-attachments/assets/c75128ce-26fb-49fb-b5ab-b5d6f5d6db5f)


