### PR TITLE
Catch error in custom url

### DIFF
--- a/Mergin/utils_auth.py
+++ b/Mergin/utils_auth.py
@@ -525,7 +525,7 @@ def mergin_server_deprecated_version(url: str) -> bool:
 def url_reachable(url: str) -> bool:
     try:
         requests.get(url, timeout=3)
-    except (requests.RequestException, urllib3.exceptions.LocationParseError, UnicodeEncodeError):
+    except (requests.RequestException, urllib3.exceptions.LocationParseError, UnicodeError):
         return False
     return True
 

--- a/Mergin/utils_auth.py
+++ b/Mergin/utils_auth.py
@@ -525,7 +525,7 @@ def mergin_server_deprecated_version(url: str) -> bool:
 def url_reachable(url: str) -> bool:
     try:
         requests.get(url, timeout=3)
-    except (requests.RequestException, urllib3.exceptions.LocationParseError):
+    except (requests.RequestException, urllib3.exceptions.LocationParseError, UnicodeEncodeError):
         return False
     return True
 


### PR DESCRIPTION
catch error that occur on macOS in python 3.9 with invalid adress like ".something.com"

Based on @RastoHu report of the error:

![screenshot_2025-07-02_at_13 53 49](https://github.com/user-attachments/assets/4066eb5f-606e-4461-a46e-170014e1f0bc)
