### PR TITLE
Toggle alphabetic sort in the project

### DIFF
--- a/Mergin/create_project_wizard.py
+++ b/Mergin/create_project_wizard.py
@@ -513,16 +513,20 @@ class NewMerginProjectWizard(QWizard):
                     elif layer_state == proxy_model.IGNORE_COL:
                         layers_to_remove.append(lid)
 
-                new_proj.removeMapLayers(layers_to_remove)
-                new_proj.write()
-                reload_project = True
+            new_proj.removeMapLayers(layers_to_remove)
+
+            new_proj.writeEntry("Mergin", "SortLayersAlphabetical/Enabled", False)
+            new_proj.write()
+            reload_project = True
 
                 # copy datum shift grids
                 package_datum_grids(os.path.join(self.project_dir, "proj"))
 
-            elif self.init_page.cur_proj_no_pack_btn.isChecked():
-                cur_proj = QgsProject.instance()
-                cur_proj.write()
+        elif self.init_page.cur_proj_no_pack_btn.isChecked():
+            cur_proj = QgsProject.instance()
+
+            cur_proj.writeEntry("Mergin", "SortLayersAlphabetical/Enabled", False)
+            cur_proj.write()
 
                 # copy datum shift grids
                 package_datum_grids(os.path.join(self.project_dir, "proj"))

--- a/Mergin/create_project_wizard.py
+++ b/Mergin/create_project_wizard.py
@@ -515,7 +515,7 @@ class NewMerginProjectWizard(QWizard):
 
             new_proj.removeMapLayers(layers_to_remove)
 
-            new_proj.writeEntry("Mergin", "SortLayersAlphabetical/Enabled", False)
+            new_proj.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
             new_proj.write()
             reload_project = True
 
@@ -525,7 +525,7 @@ class NewMerginProjectWizard(QWizard):
         elif self.init_page.cur_proj_no_pack_btn.isChecked():
             cur_proj = QgsProject.instance()
 
-            cur_proj.writeEntry("Mergin", "SortLayersAlphabetical/Enabled", False)
+            cur_proj.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
             cur_proj.write()
 
                 # copy datum shift grids

--- a/Mergin/create_project_wizard.py
+++ b/Mergin/create_project_wizard.py
@@ -513,20 +513,20 @@ class NewMerginProjectWizard(QWizard):
                     elif layer_state == proxy_model.IGNORE_COL:
                         layers_to_remove.append(lid)
 
-            new_proj.removeMapLayers(layers_to_remove)
+                new_proj.removeMapLayers(layers_to_remove)
 
-            new_proj.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
-            new_proj.write()
-            reload_project = True
+                new_proj.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
+                new_proj.write()
+                reload_project = True
 
                 # copy datum shift grids
                 package_datum_grids(os.path.join(self.project_dir, "proj"))
 
-        elif self.init_page.cur_proj_no_pack_btn.isChecked():
-            cur_proj = QgsProject.instance()
+            elif self.init_page.cur_proj_no_pack_btn.isChecked():
+                cur_proj = QgsProject.instance()
 
-            cur_proj.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
-            cur_proj.write()
+                cur_proj.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
+                cur_proj.write()
 
                 # copy datum shift grids
                 package_datum_grids(os.path.join(self.project_dir, "proj"))

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -113,12 +113,12 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
                     else:
                         item.setColor(QColor("#ffffff"))
 
-        enabled, ok = QgsProject.instance().readBoolEntry("Mergin", "SortLayersAlphabetical/Enabled")
-        if ok:
-            self.chk_sort_alphabetical.setChecked(enabled)
-        else:
-            # Backward compatibility used to be the default
-            self.chk_sort_alphabetical.setChecked(True)
+        self.cmb_sort_method.addItem("Preserve QGIS layer order ", 0)
+        self.cmb_sort_method.addItem("Alphabetical", 1)
+
+        mode, ok = QgsProject.instance().readNumEntry("Mergin", "SortLayersMethod/Method")
+        idx = self.cmb_sort_method.findData(mode) if ok else 1
+        self.cmb_sort_method.setCurrentIndex(idx)
 
         self.local_project_dir = mergin_project_local_path()
 
@@ -328,10 +328,7 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
                 expression = item.data(AttachmentFieldsModel.EXPRESSION)
                 QgsProject.instance().writeEntry("Mergin", f"PhotoNaming/{layer_id}/{field_name}", expression)
 
-        QgsProject.instance().writeEntry(
-            "Mergin", "SortLayersAlphabetical/Enabled", self.chk_sort_alphabetical.isChecked()
-        )
-
+        QgsProject.instance().writeEntry("Mergin", "SortLayersMethod/Method", self.cmb_sort_method.currentData())
         self.save_config_file()
         self.setup_tracking()
         self.setup_map_sketches()

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -113,6 +113,13 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
                     else:
                         item.setColor(QColor("#ffffff"))
 
+        enabled, ok = QgsProject.instance().readBoolEntry("Mergin", "SortLayersAlphabetical/Enabled")
+        if ok:
+            self.chk_sort_alphabetical.setChecked(enabled)
+        else:
+            # Backward compatibility used to be the default
+            self.chk_sort_alphabetical.setChecked(True)
+
         self.local_project_dir = mergin_project_local_path()
 
         if self.local_project_dir:
@@ -320,6 +327,10 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
                 field_name = item.data(AttachmentFieldsModel.FIELD_NAME)
                 expression = item.data(AttachmentFieldsModel.EXPRESSION)
                 QgsProject.instance().writeEntry("Mergin", f"PhotoNaming/{layer_id}/{field_name}", expression)
+
+        QgsProject.instance().writeEntry(
+            "Mergin", "SortLayersAlphabetical/Enabled", self.chk_sort_alphabetical.isChecked()
+        )
 
         self.save_config_file()
         self.setup_tracking()

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -44,9 +44,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-849</y>
+        <y>-888</y>
         <width>628</width>
-        <height>1424</height>
+        <height>1444</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -436,8 +436,8 @@
          <property name="title">
           <string>Set layer order</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="label_13">
             <property name="text">
              <string>This option override the default sorting layer in the mobile app to sort layer alphabetically</string>
@@ -447,10 +447,13 @@
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QCheckBox" name="chk_sort_alphabetical">
+          <item row="1" column="1">
+           <widget class="QComboBox" name="cmb_sort_method"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_14">
             <property name="text">
-             <string>Enable sort layer alphabetically</string>
+             <string>Sorting method</string>
             </property>
            </widget>
           </item>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -440,7 +440,7 @@
           <item>
            <widget class="QLabel" name="label_13">
             <property name="text">
-             <string>This option override the default sorting layer in the mobile app to layer alphabetically</string>
+             <string>This option override the default sorting layer in the mobile app to sort layer alphabetically</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -44,9 +44,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-766</y>
+        <y>-849</y>
         <width>628</width>
-        <height>1322</height>
+        <height>1424</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -323,6 +323,23 @@
           <string>Map sketching</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Colour set</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Map sketching lets mobile app users draw quick, informal sketches directly on the map. Sketches are saved in a separate GeoPackage that’s created automatically. &lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://merginmaps.com/docs/field/map-sketching&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Learn more here&lt;/span&gt;&lt;/a&gt; about how map sketching works and how to use it in the mobile app.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
            <layout class="QHBoxLayout" name="mColorsHorizontalLayout">
             <item>
@@ -404,27 +421,36 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_12">
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="chk_map_sketches_enabled">
             <property name="text">
-             <string>Colour set</string>
+             <string>Enable map sketching</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="label_11">
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Set layer order</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QLabel" name="label_13">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Map sketching lets mobile app users draw quick, informal sketches directly on the map. Sketches are saved in a separate GeoPackage that’s created automatically. &lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://merginmaps.com/docs/field/map-sketching&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Learn more here&lt;/span&gt;&lt;/a&gt; about how map sketching works and how to use it in the mobile app.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>This option override the default sorting layer in the mobile app to layer alphabetically</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="chk_map_sketches_enabled">
+          <item>
+           <widget class="QCheckBox" name="chk_sort_alphabetical">
             <property name="text">
-             <string>Enable map sketching</string>
+             <string>Enable sort layer alphabetically</string>
             </property>
            </widget>
           </item>

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -507,7 +507,7 @@ def create_basic_qgis_project(project_path=None, project_name=None):
     vector_layer.setEditorWidgetSetup(3, photo_ws)
     new_project.addMapLayer(vector_layer)
 
-    new_project.writeEntry("Mergin", "SortLayersAlphabetical/Enabled", False)
+    new_project.writeEntry("Mergin", "SortLayersMethod/Method", 0)  # 0 - Preserve QGIS layer order
 
     write_success = new_project.write()
     if not write_success:

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -507,6 +507,8 @@ def create_basic_qgis_project(project_path=None, project_name=None):
     vector_layer.setEditorWidgetSetup(3, photo_ws)
     new_project.addMapLayer(vector_layer)
 
+    new_project.writeEntry("Mergin", "SortLayersAlphabetical/Enabled", False)
+
     write_success = new_project.write()
     if not write_success:
         QMessageBox.warning(None, "Error Creating New Project", f"Couldn't create new project:\n{project_path}")


### PR DESCRIPTION
Add a toggle in the project configuration to sort layer either by qgis layer panel or by alphabetical order in the mobile app layer controller

![image](https://github.com/user-attachments/assets/2caa3fe6-c0d8-439d-9cf1-fce4685445e8)

See also [mobile/pull/3980](https://github.com/MerginMaps/mobile/pull/3980)

