### PR TITLE
Better handling of restoring overriden cursors

### DIFF
--- a/Mergin/create_project_wizard.py
+++ b/Mergin/create_project_wizard.py
@@ -18,7 +18,7 @@ from qgis.PyQt.QtWidgets import (
 )
 
 from qgis.core import QgsProject, QgsLayerTreeNode, QgsLayerTreeModel, NULL
-from qgis.utils import iface
+from qgis.utils import iface, OverrideCursor
 
 from .utils import (
     check_mergin_subdirs,
@@ -469,71 +469,65 @@ class NewMerginProjectWizard(QWizard):
         reload_project = False
         failed_packaging = []
 
-        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-        QApplication.processEvents()
-
-        if not self.init_page.cur_proj_no_pack_btn.isChecked():
-            self.project_dir = os.path.join(self.project_dir, self.project_name)
-            if not os.path.exists(self.project_dir):
-                try:
-                    os.mkdir(self.project_dir)
-                except OSError as e:
-                    msg = f"Couldn't create project directory:\n{self.project_dir}\n\n{repr(e)}"
-                    QMessageBox.critical(None, "Create New Project", msg)
-                    QApplication.restoreOverrideCursor()
-                    return
-            self.project_file = os.path.join(self.project_dir, self.project_name + ".qgz")
-
-        self.save_geometry()
-        super().accept()
-
-        if self.init_page.basic_proj_btn.isChecked():
-            self.project_file = create_basic_qgis_project(project_path=self.project_file)
-            reload_project = True
-
-        elif self.init_page.cur_proj_pack_btn.isChecked():
-            if not save_current_project(self.project_file):
-                msg = f"Couldn't save project to specified location:\n{self.project_file}."
-                msg += "\n\nCheck the path is writable and try again."
-                QMessageBox.warning(None, "Create New Project", msg)
-                return
-            proxy_model = self.package_page.layers_view.proxy_model
-            new_proj = QgsProject.instance()
-            new_root = new_proj.layerTreeRoot()
-            layers_to_remove = []
-            for tree_layer in new_root.findLayers():
-                layer = tree_layer.layer()
-                lid = tree_layer.layerId()
-                if layer is None:
-                    # this is an invalid tree node layer - let's keep it as is
-                    continue
-                layer_state = proxy_model.layers_state[lid]
-                if layer_state == proxy_model.PACK_COL:
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            if not self.init_page.cur_proj_no_pack_btn.isChecked():
+                self.project_dir = os.path.join(self.project_dir, self.project_name)
+                if not os.path.exists(self.project_dir):
                     try:
-                        package_layer(layer, self.project_dir)
-                    except PackagingError as e:
-                        failed_packaging.append((layer.name(), repr(e)))
-                elif layer_state == proxy_model.IGNORE_COL:
-                    layers_to_remove.append(lid)
+                        os.mkdir(self.project_dir)
+                    except OSError as e:
+                        msg = f"Couldn't create project directory:\n{self.project_dir}\n\n{repr(e)}"
+                        QMessageBox.critical(None, "Create New Project", msg)
+                        return
+                self.project_file = os.path.join(self.project_dir, self.project_name + ".qgz")
 
-            new_proj.removeMapLayers(layers_to_remove)
-            new_proj.write()
-            reload_project = True
+            self.save_geometry()
+            super().accept()
 
-            # copy datum shift grids
-            package_datum_grids(os.path.join(self.project_dir, "proj"))
+            if self.init_page.basic_proj_btn.isChecked():
+                self.project_file = create_basic_qgis_project(project_path=self.project_file)
+                reload_project = True
 
-        elif self.init_page.cur_proj_no_pack_btn.isChecked():
-            cur_proj = QgsProject.instance()
-            cur_proj.write()
+            elif self.init_page.cur_proj_pack_btn.isChecked():
+                if not save_current_project(self.project_file):
+                    msg = f"Couldn't save project to specified location:\n{self.project_file}."
+                    msg += "\n\nCheck the path is writable and try again."
+                    QMessageBox.warning(None, "Create New Project", msg)
+                    return
+                proxy_model = self.package_page.layers_view.proxy_model
+                new_proj = QgsProject.instance()
+                new_root = new_proj.layerTreeRoot()
+                layers_to_remove = []
+                for tree_layer in new_root.findLayers():
+                    layer = tree_layer.layer()
+                    lid = tree_layer.layerId()
+                    if layer is None:
+                        # this is an invalid tree node layer - let's keep it as is
+                        continue
+                    layer_state = proxy_model.layers_state[lid]
+                    if layer_state == proxy_model.PACK_COL:
+                        try:
+                            package_layer(layer, self.project_dir)
+                        except PackagingError as e:
+                            failed_packaging.append((layer.name(), repr(e)))
+                    elif layer_state == proxy_model.IGNORE_COL:
+                        layers_to_remove.append(lid)
 
-            # copy datum shift grids
-            package_datum_grids(os.path.join(self.project_dir, "proj"))
+                new_proj.removeMapLayers(layers_to_remove)
+                new_proj.write()
+                reload_project = True
 
-            reload_project = True
+                # copy datum shift grids
+                package_datum_grids(os.path.join(self.project_dir, "proj"))
 
-        QApplication.processEvents()
-        QApplication.restoreOverrideCursor()
+            elif self.init_page.cur_proj_no_pack_btn.isChecked():
+                cur_proj = QgsProject.instance()
+                cur_proj.write()
+
+                # copy datum shift grids
+                package_datum_grids(os.path.join(self.project_dir, "proj"))
+
+                reload_project = True
 
         ok = self.project_manager.create_project(
             self.project_name, self.project_dir, self.is_public, self.project_namespace

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -108,9 +108,7 @@ class MerginProjectsManager(object):
                         f"Projects quota: {e.server_response['projects_quota']}"
                     )
                 elif e.server_code == ErrorCode.StorageLimitHit.value:
-                    msg = (
-                        f"{e.detail}\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response['storage_limit'])}"
-                    )
+                    msg = f"{e.detail}\nCurrent limit: {bytes_to_human_size(e.server_response['storage_limit'])}"
 
                 QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
                 return False

--- a/Mergin/sync_dialog.py
+++ b/Mergin/sync_dialog.py
@@ -119,7 +119,7 @@ class SyncDialog(QDialog):
                 return
 
             assert self.job  # if there was no error thrown, we should have a job
-    
+
             # use kilobytes as a unit, so we do not need to worry about int overflow with projects of few GB size
             self.progress.setMaximum(int(self.job.total_size / 1024))
             self.progress.setValue(0)


### PR DESCRIPTION
use the `with OverrideCursor(...):` idiom instead of relying to manual `QApplication.restoreOverrideCursor()` calls.

Use `split` diff for reviewing, as it's mostly just an indentation level change.

Fixes the stuck wait cursor reported in https://github.com/MerginMaps/qgis-plugin/issues/753#issuecomment-3077608733