### PR TITLE
fix on bug  "Unable to Delete Project Locally on Windows - Python Err…

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -806,7 +806,7 @@ class MerginLocalProjectItem(QgsDirectoryItem):
                 # as releasing lock on previously open files takes some time
                 # we have to wait a bit before removing them, otherwise rmtree
                 # will fail and removal of the local rpoject will fail as well
-                QTimer.singleShot(250, lambda: shutil.rmtree(self.path))
+                QTimer.singleShot(500, lambda: shutil.rmtree(self.path))
             except PermissionError as e:
                 QgsApplication.messageLog().logMessage(f"Mergin Maps plugin: {str(e)}")
                 msg = (


### PR DESCRIPTION
fix python error. #749

On Windows, log file handlers may keep a lock on client-log.txt for a short
time even after being closed. This caused shutil.rmtree to fail with
PermissionError. Increased the QTimer delay before removal to give the OS
enough time to release the file lock.

delay 250 -> 500