### PR TITLE
Make the plugin work with QGIS 4

### DIFF
--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -2,7 +2,7 @@
 [general]
 name=Mergin
 qgisMinimumVersion=3.22
-qgisMaximumVersion=3.99
+qgisMaximumVersion=4.99
 description=Handle Mergin Maps projects
 version=2025.3.3
 author=Lutra Consulting


### PR DESCRIPTION
The current version of the plugin does not work with nightly builds of QGIS (which will be QGIS 4.0). With nightly builds, the plugin manager complains that the plugin is not compatible with QGIS version and will not load the plugin.

I did only a quick smoke test, but this change seems to be enough