### PR TITLE
Adds better unhandled exception dialog during project sync

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -181,7 +181,8 @@ class MerginProjectsManager(object):
                 unhandled_exception_message(
                     dlg.exception_details(),
                     "Project sync",
-                    f"Failed to sync project {project_name} due to an unhandled exception.",
+                    f"Something went wrong while synchronising your project {project_name}.",
+                    self.mc,
                 )
             return True
 
@@ -375,7 +376,8 @@ class MerginProjectsManager(object):
                 unhandled_exception_message(
                     dlg.exception_details(),
                     "Project sync",
-                    f"Failed to sync project {project_name} due to an unhandled exception.",
+                    f"Something went wrong while synchronising your project {project_name}.",
+                    self.mc,
                 )
             return
 
@@ -438,7 +440,8 @@ class MerginProjectsManager(object):
                 unhandled_exception_message(
                     dlg.exception_details(),
                     "Project sync",
-                    f"Failed to sync project {project_name} due to an unhandled exception.",
+                    f"Something went wrong while synchronising your project {project_name}.",
+                    self.mc,
                 )
             return
 
@@ -580,9 +583,9 @@ class MerginProjectsManager(object):
                 unhandled_exception_message(
                     dlg.exception_details(),
                     "Project download",
-                    f"Failed to download project {project_name} due to an unhandled exception.",
+                    f"Something went wrong while downloading your project {project_name}.",
+                    self.mc,
                     dlg.log_file,
-                    self.mc.username(),
                 )
             return
         if not dlg.is_complete:


### PR DESCRIPTION
Enhanced the "unhandled exception" dialog:
- sending diagnostic log did not work before (passed `username` instead of the client ref)
- does not redirect users to GH issue tracker, but our support instead
- submits diagnostic log and opens email client with `mailto:` in one click
  - `mailto` message is preformatted, includes recipient, subject, body with the error message and a placeholder for user to enter more details about what happened
- adds optional checkbox if one does not want to share the log
- contains more UX-friendly messages

Hopefully, this should redirect most of the reports to the support team so we do not need to forward it manually ourselves.

| Old | New |
|--------|--------|
| <img width="532" height="408" alt="Screenshot 2025-09-01 at 17 00 38" src="https://github.com/user-attachments/assets/52e4e9f0-9aa4-4647-87f5-b70cae82eb5b" /> | <img width="532" height="448" alt="Screenshot 2025-09-01 at 16 58 29" src="https://github.com/user-attachments/assets/24b9845d-b24f-487e-9992-81c9af83ba5a" /> |
