### PR TITLE
Update server deprecation message

### DIFF
--- a/Mergin/configuration_dialog.py
+++ b/Mergin/configuration_dialog.py
@@ -177,7 +177,7 @@ class ConfigurationDialog(QDialog):
 
             if url_reachable(self.server_url()):
                 if mergin_server_deprecated_version(self.server_url()):
-                    msg = "The server is running an older, unsupported version of Mergin Maps. Please contact your server administrator. <br> If you still require data access, please downgrade your plugin version."
+                    msg = "This server is running an unsupported version of Mergin Maps (earlier than 2023.2.0).<br>Please ask your administrator to upgrade the server to a supported version."
                     QMessageBox.information(
                         self,
                         "Deprecated server version",


### PR DESCRIPTION
Updated the deprecation message so it includes the minimum server version. 

@harminius there is a bug in the evaluation of the server type (here: https://github.com/MerginMaps/python-api-client/blob/d6e8a1676b962024009210a2057241bd8f1b093a/mergin/client.py#L389) - can you please fix it for this release? The problem is that `ServerType.OLD` is returned in case there is any error with the network request. This is wrong though, e.g. in the maintenance mode we return `503` - it does not mean the server is old, it only means that the server is down for maintenance. The function should return `OLD` only if the server returns `404`. 